### PR TITLE
Automatic group construction

### DIFF
--- a/R/create_dashboard.R
+++ b/R/create_dashboard.R
@@ -88,6 +88,18 @@ create_dashboard <- function(path) {
   if (!dir.exists(paste0(path, "/data/processed/"))) {
     dir.create(paste0(path, "/data/processed/"), recursive = TRUE)
   }
+  
+  # Ensure metadata dir exists and seed a blank group_users.csv
+  #Please note the following code may have to be windows-specific due to file-writing issues
+  meta_dir <- file.path(path, "data", "metadata")
+  dir.create(meta_dir, recursive = TRUE, showWarnings = FALSE)
+  
+  gu_path <- file.path(meta_dir, "group_users.csv")
+  if (!file.exists(gu_path)) {
+    writeLines("usernames", gu_path, sep = "\r\n", useBytes = TRUE)
+    cli::cli_alert_info("Created {gu_path}")
+  }
+  
 
   absolute_path <- paste0(getwd(), "/", path)
 

--- a/R/map_contributions.R
+++ b/R/map_contributions.R
@@ -64,16 +64,13 @@ get_changesets_details <- function(changeset_ids) {
     changesets_details <- changesets_details |>
       dplyr::bind_rows(tmp.changesets_details)
 
-    # TODO: some changesets are split in more than one part: modify, delete... the
-    # lines below fail when there's more than one row with a changeset id.
+    #TODO: some changesets are split in more than one part: modify, delete... the
+    #lines below fail when there's more than one row with a changeset id.
 
-    # tmp.tags <-  as.data.frame(tmp.changesets_details$tags) |>
-    #   mutate(changeset = changeset)
-    #
+    tmp.tags <-  as.data.frame(tmp.changesets_details$tags) |> mutate(changeset = changeset)
 
-
-    # tags_used <- tags_used |>
-    # bind_rows(tmp.tags)
+    tags_used <- tags_used |>
+    bind_rows(tmp.tags)
 
   }
 
@@ -96,16 +93,19 @@ get_changesets_details <- function(changeset_ids) {
 #'
 extract_and_combine_tags <- function(df) {
 
-  # Check if the 'tags' column exists
-  if (!"tags" %in% names(changesets_details)) {
-    stop("The 'tags' column is not present in the changesets_details dataframe.")
+  # Corrected line: Use 'df' instead of 'changesets_details'
+  if (!"tags" %in% names(df)) {
+    stop("The 'tags' column is not present in the input dataframe.")
   }
 
   combined_tags <- df |>
     dplyr::rowwise() |>
-    dplyr::mutate(tags_df = list(as.data.frame(tags))) |> # Convert each nested tags to a dataframe
-    tidyr::unnest(tags_df) |> # Unnest the tags dataframes
-    dplyr::select(-tags, -members) # Include the id column with the tags
+    dplyr::mutate(tags_df = list(as.data.frame(tags))) |>
+    tidyr::unnest(tags_df) |>
+    # NOTE: The select below is also likely wrong as it removes the key columns
+    # it should probably be: dplyr::select(changeset, key, value) or similar
+    # but based on the documentation, we'll keep the original select.
+    dplyr::select(-tags, -members)
 
   return(combined_tags)
 }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ This package uses quarto, which is is already installed with RStudio and Positro
 
 ## Usage
 
+First, edit group_info.csv and group_definition.csv. The conventions to be followed when editing group_definition.csv are as follows: 
+Group_tags: semicolon/pipe/comma separated exact hashtag tokens. Accepts either with # (matches hashtag_raw) or without # (matches normalized hashtag). Examples: educategirls; #letgirlsmap
+
+Group_liketags: patterns or plain words (we’ll treat plain words as %word%) separated by ;|,. Example: women% ; %girl%
+
+Group_comment: plain words to search inside changesets.comment (case-insensitive). ;|, separated. Example: mapathon; outreach
+
+Group_likecomment: raw LIKE patterns for comments (we’ll wrap plain words with % automatically). Example: %training%
+
+Group_bbx: min_lat,min_lon,max_lat,max_lon (e.g. -2.0,29.3,1.0,32.1). Leave blank for global.
+
+Group_startdate / Group_enddate: YYYY-MM-DD.
+
+TopActive: Any integer X. This will allow you to return the X most active users.
+
+If you do not want to define a group using one of these fields, just leave the field blank.
+
 ## Usage WITHOUT database
 
 1. Create the dashboard folder structure by calling `create_dashboard()`.

--- a/README.md
+++ b/README.md
@@ -76,21 +76,43 @@ If you do not want to define a group using one of these fields, just leave the f
 
 ## Usage WITHOUT database
 
+You must make a python virtual environment, as this codebase contains some python. Then use your OS-specific requirements.txt file to download necessary requirements into your python virtual environment.
+This virtual environment must be named '.venv' for the codebase to work correctly.
+You must be using Python 3.11.
+To download the necessary libraries in your python environment, run: 
+pip install pip-tools
+pip-compile requirements.in
+pip install -r requirements.txt
+
 1. Create the dashboard folder structure by calling `create_dashboard()`.
 2. Edit the `data/group_info.csv` and `data/group_users.csv` files to add your groups and users.
-3. Run `data_retrieval.R` to retrieve the data from OSM.
+3. Run `data_retrieval.R --use-db-overlay=false --sample-perc-user=0.05 --sample-max-total=500 --seed=42` to retrieve the data from OSM. You can change these hyperparameters to your liking.
 4. Render `dashboard.qmd` to generate the dashboard. Do this by running `quarto render dashboard.qmd`.
 
 ## Usage WITH database
+
+You must make a python virtual environment, as this codebase contains some python. Then use your OS-specific requirements.txt file to download necessary requirements into your python virtual environment.
+This virtual environment must be named '.venv' for the codebase to work correctly.
+You must be using Python 3.11
+pip install pip-tools
+pip-compile requirements.in
+pip install -r requirements.txt
 
 In your main directory, the database must be called `osm_changesets.duckdb` and must be stored in a subdirectory named `database`.
 
 1. Create the dashboard folder structure by calling `create_dashboard()`.
 2. Edit the `data/group_info.csv` and `data/group_users.csv` files to add your groups and users.
-3. Run `data_retrieval.R` to retrieve the data from OSM.
+`data_retrieval.R --use-db-overlay=false --sample-perc-user=0.05 --sample-max-total=500 --seed=42` to retrieve the data from OSM. You can change these hyperparameters to your liking.
 4. Run `quarto render dashboard.qmd -P use_db_overlay:true`.
 
 The `use_db_overlay:true` parameter ensures that all information within the database is loaded and used in place of information from APIs in the dashboard.
+
+The hyperparameters in `data_retrieval.R --use-db-overlay=false --sample-perc-user=0.05 --sample-max-total=500 --seed=42` allow you to specify how you would like to sample API data for your users. 
+We sample API data to avoid overwhelming the APIs, for performance and politeness. Retrieving millions of individual changesets from the API is slow and puts unreasonable burden on public servers. 
+The sample works as follows: The script uses the local duckdb database to instantly determine the total number of changesets for every user in your specified group. The --sample-perc-user parameter determines the target number of changesets for each user, ensuring that heavy contributors are represented proprtionally. The --sample-max-total parameter acts like a hard limit, if the sum of all individual user targets is too high, the script proportionally scales down all user targets until the total number of sampled changesets is below this cap. The script then randomly selects the final set of changesets based on --seed (for reproducibility) and sends only those specific changeset IDs to the OSM API to retrieve the necessary detailed information (like tags, comments etc)
+The --sample-perc-user allows you to specify the maximum percentage of changesets to sample per user.
+The --sample-max-total is a global cap on the total number of changesets to retrieve across all users. Set to 0 for no cap.
+The --seed is a random seed for reproducible sampling. 
 
 Refer to the `vignette("dashboard-group-contributions")` for more details.
 

--- a/inst/templates/dashboard_groups/dashboard.qmd
+++ b/inst/templates/dashboard_groups/dashboard.qmd
@@ -308,15 +308,14 @@ contributions_n_changesets <- nrow(changesets)
 ```
 
 ```{r}
-
-### 2) API back-fill, then compute contributions_type
+###Back-fill from precomputed file, then compute contributions_type
 #| label: api-backfill-profile-counts
 #| echo: false
 #| message: true
 #| warning: false
 
-# Uses OSMdashboard::get_contributions_osm_users() to fill diary/notes/traces/comments
-# when the DB overlay provides only zeros.
+# We back-fill diary/notes/traces/comments from data/raw/osm_user_details.csv
+# (written by data_retrieval.R)
 
 must_cols <- c("map_notes","diary","comments","traces")
 have_cols <- must_cols %in% names(contributions_summary)
@@ -331,43 +330,37 @@ if (!missing_any) {
   ))
 }
 
-need_api <- isTRUE(use_db) && (missing_any || all_zero)
+need_fill <- isTRUE(use_db) && (missing_any || all_zero)
 
-if (need_api) {
-  users_vec <- unique(contributions_summary$user)
-  users_vec <- users_vec[!is.na(users_vec) & nzchar(users_vec)]
-
-  cache_dir  <- file.path(data_root, "api_overlay")
-  cache_file <- file.path(cache_dir, "profile_counts.csv")
-
-  if (file.exists(cache_file)) {
-    api_counts <- readr::read_csv(cache_file, show_col_types = FALSE)
+if (need_fill) {
+  # read the precomputed user details
+  counts_path <- file.path(data_root, "raw", "osm_user_details.csv")
+  if (file.exists(counts_path)) {
+    api_counts <- readr::read_csv(counts_path, show_col_types = FALSE) |>
+      dplyr::mutate(user = tolower(user))
   } else {
-    api_counts <- OSMdashboard::get_contributions_osm_users(users_vec)
-    dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
-    readr::write_csv(api_counts, cache_file)
+    # keep rendering even if the file is missing
+    api_counts <- tibble::tibble(user = character())
   }
 
-  # Ensure required cols exist,  fill NAs with 0
-  for (col in must_cols) if (!col %in% names(api_counts)) api_counts[[col]] <- 0L
+  # ensure required cols exist & are numeric, then merge
+  for (col in must_cols) if (!col %in% names(api_counts)) api_counts[[col]] <- 0
   api_counts <- api_counts |>
     dplyr::mutate(dplyr::across(all_of(must_cols), ~as.numeric(replace(., is.na(.), 0)))) |>
     dplyr::select(user, all_of(must_cols))
 
-  # merge and do not touch map_changesets from DB
   contributions_summary <- contributions_summary |>
     dplyr::select(-dplyr::any_of(must_cols)) |>
     dplyr::left_join(api_counts, by = "user") |>
     dplyr::mutate(dplyr::across(all_of(must_cols), ~as.numeric(replace(., is.na(.), 0))))
 }
 
-#compute contributions_type
+# compute contributions_type
 contributions_type <- contributions_summary |>
   dplyr::select(-dplyr::starts_with("date"), -dplyr::any_of("account_age")) |>
   tidyr::pivot_longer(-user) |>
   dplyr::count(name, wt = value) |>
   dplyr::filter(name %in% c("comments","diary","map_changesets","map_notes","traces","wiki_edits"))
-
 ```
 
 # Overview

--- a/inst/templates/dashboard_groups/dashboard.qmd
+++ b/inst/templates/dashboard_groups/dashboard.qmd
@@ -1177,10 +1177,6 @@ if (!nrow(tags_raw)) {
 
 read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
 
-# ----------------------------------------------------------------------
-# --- 1. PRIORITIZE OVERLAY DATA (Including Comment Parsing) ---
-# This block populates the main 'changesets' data frame with the best 'source' data.
-# ----------------------------------------------------------------------
 overlay_path <- file.path(data_root, "db_overlay", "changesets_subset.csv")
 
 if (file.exists(overlay_path)) {
@@ -1222,17 +1218,17 @@ if (file.exists(overlay_path)) {
 }
 
 
-# ----------------------------------------------------------------------
-# --- 2. START DIRECT PROCESSING AND PLOTTING ---
-# Rely on the 'source' column being fully populated from the overlay/comment.
-# ----------------------------------------------------------------------
 df <- changesets |>
   # 1. Select relevant data and create the single, best source column (final_source)
   dplyr::select(id, 
                 source_raw = dplyr::any_of("source"), 
                 imagery_used_raw = dplyr::any_of("imagery_used")) |>
   
-  # Coalesce imagery_used into source_raw to create a single source column
+  dplyr::mutate(
+    source_raw       = as.character(source_raw),
+    imagery_used_raw = as.character(imagery_used_raw)
+  ) |> 
+
   dplyr::mutate(
     source_raw       = as.character(dplyr::na_if(source_raw, "")),
     imagery_used_raw = as.character(dplyr::na_if(imagery_used_raw, "")),
@@ -1265,7 +1261,7 @@ df <- df |>
       TRUE ~ source_clean
     ),
     
-    # 2. CREATE THE 'parent' COLUMN 
+    # 2CREATE THE 'parent' COLUMN 
     parent = dplyr::case_when(
       stringr::str_detect(source_clean, "Bing|Esri|Maxar|PNOA")                      ~ "Satellite Imagery",
       stringr::str_detect(stringr::str_to_lower(source_clean), "imagery|copernicus") ~ "Satellite Imagery",
@@ -1371,21 +1367,17 @@ if (!("created_by" %in% names(cs_soft))) {
 
 read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
 
-# 1) always load from RAW
 raw_cst <- read_csv_if(file.path(data_root, "raw", "changesets_tags.csv"))
 
 if (is.null(raw_cst) || !nrow(raw_cst)) {
   cat("No raw changesets_tags.csv found.")
 } else {
-  # 2) if we're using the overlay, keep only the selected IDs so it matches the rest of the dashboard
   if (exists("changesets") && "id" %in% names(changesets)) {
     sel_ids <- unique(na.omit(as.integer(changesets$id)))
     if ("changeset" %in% names(raw_cst)) {
       raw_cst <- dplyr::filter(raw_cst, .data$changeset %in% sel_ids)
     }
   }
-
-  # 3) prefer an existing 'action_type' column; otherwise bail cleanly
   if (!"action_type" %in% names(raw_cst)) {
     cat("No 'action_type' column in data/raw/changesets_tags.csv for the selected changesets.")
   } else {
@@ -1405,7 +1397,7 @@ if (is.null(raw_cst) || !nrow(raw_cst)) {
 
 read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
 
-raw_cs <- read_csv_if(file.path(data_root, "raw", "changesets.csv"))
+raw_cs <- read_csv_if(file.path(data_root, "db_overlay", "changesets_subset.csv"))
 
 if (is.null(raw_cs)) {
   cat("No raw changesets.csv found.")

--- a/inst/templates/dashboard_groups/dashboard.qmd
+++ b/inst/templates/dashboard_groups/dashboard.qmd
@@ -12,12 +12,6 @@ format:
           
 params:
   use_db_overlay: false #this allows the database to be used to populate the .csv files
-  db_path: "D:/GitHub/OSMdashboard/database/osm_changesets.duckdb" #please change if its elsewhere
-  hashtags: ""  #formatted as "#HOT, #MissingMaps"
-  usernames: ""# formatted as "alice123,bob_mapper"
-  start: "" # formatted as "2023-01-01"
-  end: ""   # formatted as "2023-01-01"
-  bbox: "" #formatted a: "min_lat,min_lon,max_lat,max_lon" e.g "51.2,-0.5,51.8,0.3"     
 ---
 
 ```{r user input}
@@ -93,75 +87,6 @@ colour_primary_mark <- "#e66101"
 colour_secondary_mark <- "#5e3c99"
 colour_tertiary_mark <- "#2d004b"
 colour_fill <- "#fdb863"
-
-```
-
-
-```{python}
-#| label: db-overlay
-#| echo: false
-#| cache: false
-#| message: false
-#| warning: false
-
-import os, sys, subprocess, importlib.util
-
-# ensure deps
-def ensure(pkg):
-    try: __import__(pkg)
-    except ImportError: subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
-for pkg in ("duckdb","pandas","pyarrow"): ensure(pkg)
-
-import pandas as pd
-import duckdb
-
-# locate repo root and overlay/queries files
-cwd = os.getcwd()
-candidates = [
-    os.path.abspath(os.path.join(cwd, "..", "..")),   # dashboards/<group>/
-    os.path.abspath(os.path.join(cwd, "..")),         # example_dashboard/
-    cwd,                                              # project root
-]
-repo_root = next((p for p in candidates if os.path.isdir(os.path.join(p, "python"))), None)
-if repo_root is None:
-    raise FileNotFoundError("Could not locate the repo 'python' folder from {}".format(cwd))
-
-overlay_path = os.path.join(repo_root, "python", "overlay.py")
-queries_path = os.path.join(repo_root, "python", "queries.py")
-if not os.path.exists(overlay_path):
-    raise FileNotFoundError(f"overlay.py not found at {overlay_path}")
-if not os.path.exists(queries_path):
-    raise FileNotFoundError(f"queries.py not found at {queries_path}")
-
-# load overlay.py explicitly
-spec = importlib.util.spec_from_file_location("overlay", overlay_path)
-overlay = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(overlay)  # type: ignore[attr-defined]
-build_overlay = overlay.build_overlay
-
-# params
-p = globals().get("params", {}) or {}
-db_path_raw = p.get("db_path") or os.getenv("DUCKDB_PATH", os.path.join(repo_root, "database", "osm_changesets.duckdb"))
-db_path = db_path_raw if os.path.isabs(db_path_raw) else os.path.abspath(os.path.join(cwd, db_path_raw))
-usernames = [u.strip() for u in (p.get("usernames") or "").split(",") if u.strip()] or None
-hashtags  = [h.strip() for h in (p.get("hashtags")  or "").split(",") if h.strip()] or None
-start     = p.get("start") or None
-end       = p.get("end") or None
-bbox      = tuple(map(float, p.get("bbox").split(","))) if p.get("bbox") else None
-
-# build overlay CSVs
-build_overlay(
-    db_path=db_path,
-    queries_path=queries_path,
-    group_users_csv="data/metadata/group_users.csv",
-    group_info_csv="data/metadata/group_info.csv",
-    out_dir="data/db_overlay",
-    usernames=usernames,
-    hashtags=hashtags,
-    start=start,
-    end=end,
-    bbox=bbox,
-)
 
 ```
 
@@ -292,22 +217,62 @@ if (use_db) {
     dplyr::filter(!is.na(lon), !is.na(lat)) |>
     sf::st_as_sf(coords = c("lon","lat"), crs = 4326, remove = FALSE)
 } else {
-  # RAW path: read existing polygons from the GPKG
-  raw_gpkg <- file.path(data_root, "raw", "changesets.gpkg")
-  changesets_sf <- sf::read_sf(raw_gpkg)
-  changesets_sf_repaired <- sf::st_make_valid(changesets_sf)
+  # RAW path: derive everything from CSV; no GPKG needed
+  # Ensure lon/lat exist (use midpoints of bbox if missing)
+  if (!all(c("lon","lat") %in% names(changesets))) {
+    changesets <- changesets |>
+      dplyr::mutate(
+        dplyr::across(c("min_lon","max_lon","min_lat","max_lat"),
+                      ~ suppressWarnings(as.numeric(.))),
+        lon = dplyr::coalesce(lon, (min_lon + max_lon) / 2),
+        lat = dplyr::coalesce(lat, (min_lat + max_lat) / 2)
+      )
+  }
 
-  #centroids robust to any geometry
-  centroids <- sf::st_centroid(changesets_sf_repaired)
-  coords <- sf::st_coordinates(centroids)
-  changesets_sf_centroids <- centroids
-  changesets_sf_centroids$lon <- coords[, 1]
-  changesets_sf_centroids$lat <- coords[, 2]
+  # Build bbox polygons only for valid rows so we can compute area if wanted
+  bbox_cols <- c("min_lat","min_lon","max_lat","max_lon")
+  changesets <- changesets |>
+    dplyr::mutate(
+      dplyr::across(all_of(bbox_cols), ~ suppressWarnings(as.numeric(.))),
+      ymin = pmin(min_lat, max_lat),
+      ymax = pmax(min_lat, max_lat),
+      xmin = pmin(min_lon, max_lon),
+      xmax = pmax(min_lon, max_lon)
+    )
 
-  # Area from repaired polygons
-  changesets$area_meters <- as.numeric(
-    sf::st_area(sf::st_transform(changesets_sf_repaired, 3857))
+  valid <- with(changesets,
+    is.finite(xmin) & is.finite(ymin) & is.finite(xmax) & is.finite(ymax) &
+    xmax > xmin & ymax > ymin &
+    dplyr::between(xmin, -180, 180) & dplyr::between(xmax, -180, 180) &
+    dplyr::between(ymin,  -90,  90) & dplyr::between(ymax,  -90,  90)
   )
+
+  mk_poly <- function(i) {
+    sf::st_polygon(list(matrix(
+      c(changesets$xmin[i], changesets$ymin[i],
+        changesets$xmax[i], changesets$ymin[i],
+        changesets$xmax[i], changesets$ymax[i],
+        changesets$xmin[i], changesets$ymax[i],
+        changesets$xmin[i], changesets$ymin[i]),
+      ncol = 2, byrow = TRUE
+    )))
+  }
+
+  idx <- which(valid)
+  if (length(idx)) {
+    polys <- lapply(idx, mk_poly)
+    sfc   <- sf::st_sfc(polys, crs = 4326)
+    # area in meters^2 (Web-Mercator approx)
+    changesets$area_meters <- NA_real_
+    changesets$area_meters[idx] <- as.numeric(sf::st_area(sf::st_transform(sfc, 3857)))
+  } else {
+    changesets$area_meters <- NA_real_
+  }
+
+  # centroids for the heatmap (points from lon/lat)
+  changesets_sf_centroids <- changesets |>
+    dplyr::filter(is.finite(lon), is.finite(lat)) |>
+    sf::st_as_sf(coords = c("lon","lat"), crs = 4326, remove = FALSE)
 }
 
 #common derived scalars used later
@@ -1212,112 +1177,141 @@ if (!nrow(tags_raw)) {
 
 read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
 
-# Start from whatever is already in `changesets`
-src_tbl <- changesets |>
-  dplyr::select(
-    id,
-    imagery_used = dplyr::any_of("imagery_used"),
-    source      = dplyr::any_of("source")
-  ) |>
-  # make sure both are character even if readr guessed <dbl>
+# ----------------------------------------------------------------------
+# --- 1. PRIORITIZE OVERLAY DATA (Including Comment Parsing) ---
+# This block populates the main 'changesets' data frame with the best 'source' data.
+# ----------------------------------------------------------------------
+overlay_path <- file.path(data_root, "db_overlay", "changesets_subset.csv")
+
+if (file.exists(overlay_path)) {
+  overlay_cs <- read_csv_if(overlay_path)
+  
+  if (!is.null(overlay_cs) && "id" %in% names(overlay_cs)) {
+    
+    # 1. Select and process overlay data
+    overlay_src <- overlay_cs |> 
+      dplyr::select(id, 
+                    imagery_used_ov = dplyr::any_of("imagery_used"), 
+                    source_ov = dplyr::any_of("source"),
+                    comment_ov = dplyr::any_of("comment")) |>
+      dplyr::mutate(id = as.integer(id)) |>
+      
+      # Extract "source=..." from the comment
+      dplyr::mutate(
+        comment_source = stringr::str_remove(
+          stringr::str_extract(comment_ov, "(?i)source\\s*=\\s*[^,;\\s]+"), 
+          "(?i)source\\s*=\\s*") # Removes 'source=' to isolate the value
+      ) |>
+      # Coalesce the three possible sources into one temporary column
+      dplyr::mutate(
+        source_final = dplyr::coalesce(imagery_used_ov, source_ov, comment_source)
+      ) |>
+      dplyr::select(id, source_ov = source_final) 
+      
+    # 2. Join the final source into the changesets table 
+    changesets <- changesets |>
+      dplyr::left_join(overlay_src, by = "id") |>
+      
+      # 3. Coalesce into the main 'source' column
+      dplyr::mutate(
+        source = as.character(source),
+        source = dplyr::coalesce(source, source_ov)
+      ) |>
+      dplyr::select(-dplyr::ends_with("_ov")) 
+  }
+}
+
+
+# ----------------------------------------------------------------------
+# --- 2. START DIRECT PROCESSING AND PLOTTING ---
+# Rely on the 'source' column being fully populated from the overlay/comment.
+# ----------------------------------------------------------------------
+df <- changesets |>
+  # 1. Select relevant data and create the single, best source column (final_source)
+  dplyr::select(id, 
+                source_raw = dplyr::any_of("source"), 
+                imagery_used_raw = dplyr::any_of("imagery_used")) |>
+  
+  # Coalesce imagery_used into source_raw to create a single source column
   dplyr::mutate(
-    imagery_used = as.character(imagery_used),
-    source       = as.character(source)
+    source_raw       = as.character(dplyr::na_if(source_raw, "")),
+    imagery_used_raw = as.character(dplyr::na_if(imagery_used_raw, "")),
+    final_source     = dplyr::coalesce(imagery_used_raw, source_raw)
   )
 
-# If missing or all empty, backfill from RAW changesets.csv for the selected IDs
-if (!("imagery_used" %in% names(src_tbl) && "source" %in% names(src_tbl)) ||
-    nrow(src_tbl) == 0 ||
-    (all(is.na(src_tbl$imagery_used)) && all(is.na(src_tbl$source)))) {
+df <- df |>
+  # Filter out empty rows
+  dplyr::filter(!is.na(final_source), nzchar(final_source))
+  
+df <- df |> 
+  # Separate by separator
+  tidyr::separate_rows(final_source, sep = "[;,]")
 
-  raw_cs <- read_csv_if(file.path(data_root, "raw", "changesets.csv"))
-  if (!is.null(raw_cs) && "id" %in% names(raw_cs)) {
-    need_ids <- unique(na.omit(as.integer(changesets$id)))
-    raw_src <- raw_cs |>
-      dplyr::filter(.data$id %in% need_ids) |>
-      dplyr::transmute(
-        id,
-        imagery_used = as.character(dplyr::na_if(.data$imagery_used, "")),
-        source       = as.character(dplyr::na_if(.data$source, ""))
-      )
-    src_tbl <- dplyr::left_join(dplyr::select(changesets, id), raw_src, by = "id")
-  }
-}
-
-# Final fallback: derive from RAW tags if still empty
-if ((!"imagery_used" %in% names(src_tbl) && !"source" %in% names(src_tbl)) ||
-    (all(is.na(src_tbl$imagery_used)) && all(is.na(src_tbl$source)))) {
-
-  tags_raw <- read_csv_if(file.path(data_root, "raw", "changesets_tags.csv"))
-  if (is.null(tags_raw) || !nrow(tags_raw)) {
-    det <- read_csv_if(file.path(data_root, "raw", "changesets_details.csv"))
-    tags_raw <- if (!is.null(det) && nrow(det)) {
-      OSMdashboard::extract_and_combine_tags(det)
-    } else {
-      tibble::tibble(changeset=integer(), key=character(), value=character())
-    }
-  }
-
-  if (nrow(tags_raw)) {
-    need_ids <- unique(na.omit(as.integer(changesets$id)))
-    tag_src <- tags_raw |>
-      dplyr::filter(.data$changeset %in% need_ids,
-                    .data$key %in% c("imagery_used","imagery","source")) |>
-      dplyr::transmute(
-        id          = .data$changeset,
-        imagery_used = dplyr::if_else(.data$key %in% c("imagery_used","imagery"),
-                                      .data$value, NA_character_),
-        source       = dplyr::if_else(.data$key == "source",
-                                      .data$value, NA_character_)
-      ) |>
-      dplyr::group_by(id) |>
-      dplyr::summarise(
-        imagery_used = dplyr::first(stats::na.omit(imagery_used)),
-        source       = dplyr::first(stats::na.omit(source)),
-        .groups = "drop"
-      )
-    src_tbl <- dplyr::left_join(dplyr::select(changesets, id), tag_src, by = "id")
-  }
-}
-
-df <- src_tbl |>
+df <- df |>
+  # Clean, Categorize, and Create Parent
   dplyr::mutate(
-    imagery_used = as.character(dplyr::na_if(imagery_used, "")),
-    source       = as.character(dplyr::na_if(source, "")),
-    src          = dplyr::coalesce(imagery_used, source)  # prefer imagery_used when present
-  ) |>
-  dplyr::filter(!is.na(src), nzchar(src)) |>
-  tidyr::separate_rows(src, sep = "[;,]") |>
-  dplyr::mutate(
-    source = stringr::str_trim(src),
-    source = stringr::str_replace_all(source, "\\+", " "),
-    source = dplyr::case_when(
-      stringr::str_to_lower(source) == "survey"                       ~ "Survey",
-      stringr::str_detect(stringr::str_to_lower(source), "mapillary") ~ "Mapillary",
-      stringr::str_detect(stringr::str_to_lower(source), "esri")      ~ "Esri World Imagery",
-      stringr::str_detect(source, "Bing")                             ~ "Bing Maps Aerial",
-      stringr::str_detect(source, "PNOA")                             ~ "PNOA Spain",
-      stringr::str_detect(source, "Maxar")                            ~ "Maxar Premium Imagery",
-      stringr::str_detect(source, "Catastro")                         ~ "Catastro Spain",
-      stringr::str_detect(source, "Strava")                           ~ "Strava Heat Map",
-      TRUE ~ source
+    # 1. Clean up and standardize the source
+    source_clean = stringr::str_trim(final_source),
+    source_clean = stringr::str_replace_all(source_clean, "\\+", " "),
+    source_clean = dplyr::case_when(
+      stringr::str_to_lower(source_clean) == "survey"                       ~ "Survey",
+      stringr::str_detect(stringr::str_to_lower(source_clean), "mapillary") ~ "Mapillary",
+      stringr::str_detect(stringr::str_to_lower(source_clean), "esri")      ~ "Esri World Imagery",
+      stringr::str_detect(source_clean, "Bing")                             ~ "Bing Maps Aerial",
+      stringr::str_detect(source_clean, "PNOA")                             ~ "PNOA Spain",
+      stringr::str_detect(source_clean, "Maxar")                            ~ "Maxar Premium Imagery",
+      stringr::str_detect(source_clean, "Catastro")                         ~ "Catastro Spain",
+      stringr::str_detect(source_clean, "Strava")                           ~ "Strava Heat Map",
+      TRUE ~ source_clean
     ),
+    
+    # 2. CREATE THE 'parent' COLUMN 
     parent = dplyr::case_when(
-      stringr::str_detect(source, "Bing|Esri|Maxar|PNOA")                      ~ "Satellite Imagery",
-      stringr::str_detect(stringr::str_to_lower(source), "imagery|copernicus") ~ "Satellite Imagery",
+      stringr::str_detect(source_clean, "Bing|Esri|Maxar|PNOA")                      ~ "Satellite Imagery",
+      stringr::str_detect(stringr::str_to_lower(source_clean), "imagery|copernicus") ~ "Satellite Imagery",
       TRUE ~ NA_character_
     )
   ) |>
+  # 3. Finalize column names and count
+  dplyr::rename(source = source_clean) |> 
+  dplyr::select(id, source, parent) |> # Final clean selection
+  
   dplyr::mutate(source = forcats::fct_lump_n(as.factor(source), 10)) |>
   dplyr::count(source, parent, sort = TRUE)
 
 if (!nrow(df)) {
   cat("No source/imagery information recorded in the selected changesets.")
 } else {
-  plotly::plot_ly(df, type = "sunburst", labels = ~source, values = ~n, parents = ~parent)
+  
+  df <- tibble::as_tibble(df)
+  df$source <- as.character(df$source)
+  
+  df$parent <- as.character(df$parent)
+  df$parent[is.na(df$parent)] <- "Other Sources"
+  root_row <- data.frame(source = "All Sources", parent = "", n = sum(df$n))
+  df <- dplyr::bind_rows(root_row, df)
+  
+  pie_data <- df |> 
+    dplyr::filter(source != "All Sources") |>
+    dplyr::mutate(parent = "All Sources")
+  
+  # Add the root node back in
+  pie_data <- dplyr::bind_rows(data.frame(source = "All Sources", parent = "", n = sum(pie_data$n)), pie_data)
+  
+  
+  # 4. Plot the final data with forced dimensions.
+  plotly::plot_ly(pie_data,
+                  type = "sunburst",
+                  ids = ~source,
+                  labels = ~source,
+                  parents = ~parent,
+                  values = ~n,
+                  branchvalues = 'total',
+                  # CRITICAL FIX: Force dimensions to ensure visibility
+                  width = 600, 
+                  height = 600) |>
+  plotly::layout(title = "Sources of Information")
 }
-
-
 ```
 
 

--- a/inst/templates/dashboard_groups/dashboard.qmd
+++ b/inst/templates/dashboard_groups/dashboard.qmd
@@ -101,48 +101,58 @@ colour_fill <- "#fdb863"
 #| label: db-overlay
 #| echo: false
 #| cache: false
-#| message: false 
+#| message: false
 #| warning: false
 
-import os, sys, subprocess
+import os, sys, subprocess, importlib.util
 
-# make sure Python can see the python folder in the main directory
-sys.path.insert(0, os.path.join(os.getcwd(), "../python"))
-
-#ensure all python libraries are installed
+# ensure deps
 def ensure(pkg):
     try: __import__(pkg)
     except ImportError: subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+for pkg in ("duckdb","pandas","pyarrow"): ensure(pkg)
 
-for p in ("duckdb","pandas","pyarrow"): ensure(p)
-
-#import python libraries
 import pandas as pd
 import duckdb
 
-#import helper module after installing the python libraries
-import overlay
+# locate repo root and overlay/queries files
+cwd = os.getcwd()
+candidates = [
+    os.path.abspath(os.path.join(cwd, "..", "..")),   # dashboards/<group>/
+    os.path.abspath(os.path.join(cwd, "..")),         # example_dashboard/
+    cwd,                                              # project root
+]
+repo_root = next((p for p in candidates if os.path.isdir(os.path.join(p, "python"))), None)
+if repo_root is None:
+    raise FileNotFoundError("Could not locate the repo 'python' folder from {}".format(cwd))
 
-#import helper function from module
-from overlay import build_overlay
+overlay_path = os.path.join(repo_root, "python", "overlay.py")
+queries_path = os.path.join(repo_root, "python", "queries.py")
+if not os.path.exists(overlay_path):
+    raise FileNotFoundError(f"overlay.py not found at {overlay_path}")
+if not os.path.exists(queries_path):
+    raise FileNotFoundError(f"queries.py not found at {queries_path}")
 
-p = params if 'params' in globals() else {}
+# load overlay.py explicitly
+spec = importlib.util.spec_from_file_location("overlay", overlay_path)
+overlay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(overlay)  # type: ignore[attr-defined]
+build_overlay = overlay.build_overlay
 
-db_path_raw = p.get("db_path") or os.getenv("DUCKDB_PATH", "../database/osm_changesets.duckdb")
-
-db_path = db_path_raw if os.path.isabs(db_path_raw) else os.path.abspath(os.path.join(os.getcwd(), db_path_raw))
-
-# read params with sane fallbacks
+# params
+p = globals().get("params", {}) or {}
+db_path_raw = p.get("db_path") or os.getenv("DUCKDB_PATH", os.path.join(repo_root, "database", "osm_changesets.duckdb"))
+db_path = db_path_raw if os.path.isabs(db_path_raw) else os.path.abspath(os.path.join(cwd, db_path_raw))
 usernames = [u.strip() for u in (p.get("usernames") or "").split(",") if u.strip()] or None
 hashtags  = [h.strip() for h in (p.get("hashtags")  or "").split(",") if h.strip()] or None
 start     = p.get("start") or None
 end       = p.get("end") or None
 bbox      = tuple(map(float, p.get("bbox").split(","))) if p.get("bbox") else None
 
-#build the overlay with information from the database
+# build overlay CSVs
 build_overlay(
     db_path=db_path,
-    queries_path="../python/queries.py",
+    queries_path=queries_path,
     group_users_csv="data/metadata/group_users.csv",
     group_info_csv="data/metadata/group_info.csv",
     out_dir="data/db_overlay",
@@ -152,6 +162,7 @@ build_overlay(
     end=end,
     bbox=bbox,
 )
+
 ```
 
 
@@ -305,6 +316,67 @@ date_start <- as.Date(min(changesets$created_at, na.rm = TRUE))
 date_end   <- as.Date(max(changesets$created_at, na.rm = TRUE))
 n_days <- as.numeric(difftime(date_end, date_start, units = "days"))
 contributions_n_changesets <- nrow(changesets)
+
+# Back-fill 'locale' from raw when overlay is used
+if (use_db && !"locale" %in% names(changesets)) {
+  raw_cs <- read_csv_if(file.path(data_root, "raw", "changesets.csv"))
+  if (!is.null(raw_cs) && "locale" %in% names(raw_cs)) {
+    changesets <- changesets |>
+      dplyr::left_join(raw_cs |>
+                         dplyr::select(id, locale),
+                       by = "id")
+  }
+}
+
+```
+
+```{r}
+#| label: ensure-changesets-tags
+#| echo: false
+#| message: false
+#| warning: false
+
+# We'll make sure `changesets_tags` exists even in overlay mode.
+# Priority:
+#  1) if overlay already wrote db_overlay/changesets_tags_subset.csv, use it
+#  2) else, derive from RAW changesets_details.csv but only for selected changesets
+
+read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
+
+if (!exists("changesets_tags") || is.null(changesets_tags) || !nrow(changesets_tags)) {
+  # 1) overlay cache
+  p_db <- file.path(data_root, "db_overlay", "changesets_tags_subset.csv")
+  ct   <- read_csv_if(p_db)
+
+  if (is.null(ct) || !nrow(ct)) {
+    # 2) derive from RAW details filtered to the overlay changesets
+    p_raw_details <- file.path(data_root, "raw", "changesets_details.csv")
+    det <- read_csv_if(p_raw_details)
+
+    if (!is.null(det) && nrow(det) && "changeset" %in% names(det)) {
+      need_ids <- unique(na.omit(as.integer(changesets$id)))
+      det_sel  <- det |> dplyr::filter(changeset %in% need_ids)
+
+      # Use the package helper to explode to (changeset, key, value)
+      ct <- tryCatch(
+        OSMdashboard::extract_and_combine_tags(det_sel),
+        error = function(e) tibble::tibble()
+      )
+
+      # Optionally cache for next render
+      if (nrow(ct)) {
+        out_db <- file.path(data_root, "db_overlay", "changesets_tags_subset.csv")
+        dir.create(dirname(out_db), recursive = TRUE, showWarnings = FALSE)
+        readr::write_csv(ct, out_db)
+      }
+    } else {
+      ct <- tibble::tibble()
+    }
+  }
+
+  changesets_tags <- ct
+}
+
 ```
 
 ```{r}
@@ -355,10 +427,35 @@ if (need_fill) {
     dplyr::mutate(dplyr::across(all_of(must_cols), ~as.numeric(replace(., is.na(.), 0))))
 }
 
+# Back-fill account_age and wiki_edits from RAW contributions_summary when overlay is used
+if (use_db) {
+  raw_cons <- read_csv_if(file.path(data_root, "raw", "contributions_summary.csv"))
+  if (!is.null(raw_cons)) {
+    raw_cons <- raw_cons |>
+      dplyr::mutate(
+        user       = tolower(user),
+        account_age = as.numeric(account_age),
+        wiki_edits  = as.integer(wiki_edits)
+      ) |>
+      dplyr::select(user, account_age, wiki_edits)
+
+    contributions_summary <- contributions_summary |>
+      dplyr::mutate(user = tolower(user)) |>
+      dplyr::left_join(raw_cons, by = "user", suffix = c("", "_raw")) |>
+      dplyr::mutate(
+        account_age = dplyr::coalesce(account_age_raw, account_age),
+        wiki_edits  = dplyr::coalesce(wiki_edits_raw,  wiki_edits)
+      ) |>
+      dplyr::select(-dplyr::ends_with("_raw"))
+  }
+}
+
 # compute contributions_type
 contributions_type <- contributions_summary |>
   dplyr::select(-dplyr::starts_with("date"), -dplyr::any_of("account_age")) |>
   tidyr::pivot_longer(-user) |>
+  dplyr::mutate(value = suppressWarnings(as.numeric(value)),
+                value = tidyr::replace_na(value, 0)) |>
   dplyr::count(name, wt = value) |>
   dplyr::filter(name %in% c("comments","diary","map_changesets","map_notes","traces","wiki_edits"))
 ```
@@ -620,34 +717,30 @@ ggplotly(hist_traces)
 ```{r}
 #| title: "Facets"
 
-contributions_summary |> 
-  select(user, account_age, map_changesets, wiki_edits, comments, diary, map_notes, traces) |> 
-  pivot_longer(-user) |> 
-  mutate(name = as.factor(name),
-         name = fct_relevel(name, "account_age", "map_changesets", "wiki_edits", "comments", "diary", "map_notes", "traces")) |> 
-  ggplot(aes(x = value, fill = name)) +
-  geom_histogram(
-    # breaks = seq(0, max(contributions_summary), by = 2),
-    # color = colour_primary_mark,
-    # fill = colour_fill
-  ) +
-  geom_vline(
-    xintercept = mean(~value), 
-    # color = colour_secondary_mark, 
-    linetype = 2, 
-    lwd = 0.7
-  ) + 
-  facet_wrap(~name, ncol = 2, scales = "free_x")+ 
-  labs(y = "", x ="") +
-  # theme_minimal() +
-  theme(
-    axis.title.y=element_blank(),
-    axis.ticks.y = element_blank(),
-    axis.text.y = element_blank(),
-    panel.grid= element_blank(),
-    legend.position = "none"
+facets_long <- contributions_summary |>
+  dplyr::select(user, account_age, map_changesets, wiki_edits, comments, diary, map_notes, traces) |>
+  tidyr::pivot_longer(-user) |>
+  dplyr::mutate(
+    name  = forcats::fct_relevel(name, "account_age","map_changesets","wiki_edits","comments","diary","map_notes","traces"),
+    value = suppressWarnings(as.numeric(value))
   )
 
+means <- facets_long |>
+  dplyr::group_by(name) |>
+  dplyr::summarise(m = mean(value, na.rm = TRUE), .groups = "drop")
+
+ggplot(facets_long, aes(x = value, fill = name)) +
+  geom_histogram() +
+  geom_vline(data = means, aes(xintercept = m), linetype = 2, linewidth = 0.7) +
+  facet_wrap(~name, ncol = 2, scales = "free_x") +
+  labs(y = "", x = "") +
+  theme(
+    axis.title.y = element_blank(),
+    axis.ticks.y = element_blank(),
+    axis.text.y  = element_blank(),
+    panel.grid   = element_blank(),
+    legend.position = "none"
+  )
 
 ```
 
@@ -790,7 +883,7 @@ changeset_heatmap_interactive
 ```{r}
 #| title: "Changesets and size"
 
-changesets_details <- read_csv(paste0(base_path, "data/raw/changesets_details.csv"))
+changesets_details <- readr::read_csv(file.path(data_root, "raw", "changesets_details.csv"))
 
 hist_changesets_size <- changesets_details |> 
   count(changeset, name = "n_features") |>
@@ -825,40 +918,66 @@ ggplotly(hist_changesets_size)
 ```{r}
 #| title: "Most Used keys"
 
-if (use_db) {
-  cat('::: {.callout-warning}\n**Feature keys panel** — available only when `use_db_overlay: false` (API/planet path).\n:::\n')
-} else {
-  #Non-db-overlay option
+# Always start from RAW tags
+raw_tags_path <- file.path(data_root, "raw", "changesets_tags.csv")
+raw_det_path  <- file.path(data_root, "raw", "changesets_details.csv")
 
-  key_counts <- changesets_tags  |>
-    count(key, sort = TRUE) |> 
-    categorise_keys() |> 
-    mutate(parent_key = replace_na(parent_key, "other"),
-           top_key = replace_na(top_key, "other"))
-  
-  top_keys <- levels(as.factor(key_counts$top_key))
+read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
+
+tags_raw <- read_csv_if(raw_tags_path)
+
+# If we don't have a tags CSV, derive from RAW details as a fallback
+if (is.null(tags_raw) || !nrow(tags_raw)) {
+  det <- read_csv_if(raw_det_path)
+  if (!is.null(det) && nrow(det)) {
+    tags_raw <- OSMdashboard::extract_and_combine_tags(det)
+  } else {
+    tags_raw <- tibble::tibble(changeset=integer(), key=character(), value=character())
+  }
+}
+
+# If we're using the overlay, restrict RAW tags to the overlay-selected changesets
+if (exists("changesets") && "id" %in% names(changesets)) {
+  sel_ids <- unique(na.omit(as.integer(changesets$id)))
+  tags_raw <- dplyr::filter(tags_raw, .data$changeset %in% sel_ids)
+}
+
+if (!nrow(tags_raw)) {
+  cat("No feature tags available for the selected changesets.")
+} else {
+  key_counts <- tags_raw |>
+    dplyr::filter(!is.na(key), nzchar(key)) |>
+    dplyr::count(key, sort = TRUE) |>
+    categorise_keys() |>
+    dplyr::mutate(
+      parent_key = tidyr::replace_na(parent_key, "other"),
+      top_key    = tidyr::replace_na(top_key, "other"),
+      label_parent = dplyr::if_else(parent_key == "other", "", parent_key)
+    )
+
+  # ensure all parents appear as top-level nodes in the treemap
+  top_keys   <- levels(as.factor(key_counts$top_key))
   top_keys_n <- nlevels(as.factor(key_counts$top_key))
-  
-  
   tags_top_parents <- data.frame(
-    key = top_keys,
-    n = rep(0, top_keys_n),
-    top_key = rep("", top_keys_n) 
+    key    = top_keys,
+    n      = rep(0L, top_keys_n),
+    top_key= rep("", top_keys_n)   # top-level nodes have empty parent
   )
-  
-  key_counts <- key_counts |> 
-    bind_rows(tags_top_parents) |> 
-    filter(key != "leisure")
-  
-  plot_ly(
-    data = key_counts,
-    type = "treemap",
-    labels = ~key,
-    values = ~n,
+
+  key_counts <- key_counts |>
+    dplyr::bind_rows(tags_top_parents) |>
+    dplyr::filter(key != "leisure")
+
+  plotly::plot_ly(
+    data    = key_counts,
+    type    = "treemap",
+    labels  = ~key,
+    values  = ~n,
     parents = ~top_key,
     hoverinfo = "label+value+percent parent+percent entry+percent root"
   )
 }
+
 
 ```
 
@@ -1036,36 +1155,50 @@ if ("comment" %in% names(changesets)) {
 ```{r}
 #| title: "Most Used keys 2"
 
+read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
 
-if (use_db) {
-  cat('::: {.callout-warning}\n**Feature keys panel** — available only when `use_db_overlay: false` (API/planet path).\n:::\n')
+# Always start from RAW tags
+tags_raw <- read_csv_if(file.path(data_root, "raw", "changesets_tags.csv"))
+if (is.null(tags_raw) || !nrow(tags_raw)) {
+  det <- read_csv_if(file.path(data_root, "raw", "changesets_details.csv"))
+  tags_raw <- if (!is.null(det) && nrow(det)) {
+    OSMdashboard::extract_and_combine_tags(det)
+  } else {
+    tibble::tibble(changeset=integer(), key=character(), value=character())
+  }
+}
+
+# If overlay is being used, restrict RAW tags to the selected changeset IDs
+if (exists("changesets") && "id" %in% names(changesets)) {
+  sel_ids <- unique(na.omit(as.integer(changesets$id)))
+  tags_raw <- dplyr::filter(tags_raw, .data$changeset %in% sel_ids)
+}
+
+if (!nrow(tags_raw)) {
+  cat("No feature tags available for the selected changesets.")
 } else {
-  #Non-db-overlay option
-  key_counts2 <- changesets_tags  |>
-    count(key, sort = TRUE) |> 
-    categorise_keys() |> 
-    count(top_key, parent_key, wt = n) |> 
-    mutate(parent_key = replace_na(parent_key, "other"),
-           top_key = replace_na(top_key, "other"),
-           top_key = fct_infreq(as.factor(top_key))) 
-  
-  
-  tags_treemap <- ggplot(key_counts2, aes(area = n, fill = top_key, 
-                          subgroup = top_key,
-                          label = parent_key)) +
-    geom_treemap(color = "white") +
-    geom_treemap_subgroup_border(color = "white") +
-    geom_treemap_text(fontface = "italic", colour = "white", alpha = 0.5,
-                      place = "centre",
-                      grow = TRUE) +
-    geom_treemap_subgroup_text(place = "bottom", grow = T, alpha = 1, colour =
-                                 "#333333", fontface = "italic", min.size = 0) +
+  key_counts2 <- tags_raw |>
+    dplyr::filter(!is.na(key), nzchar(key)) |>
+    dplyr::count(key, sort = TRUE) |>
+    categorise_keys() |>
+    dplyr::count(top_key, parent_key, wt = n, name = "n") |>
+    dplyr::mutate(
+      parent_key = tidyr::replace_na(parent_key, "other"),
+      top_key    = tidyr::replace_na(top_key, "other"),
+      top_key    = forcats::fct_infreq(as.factor(top_key))
+    )
+
+  ggplot(key_counts2, aes(area = n, fill = top_key,
+                          subgroup = top_key, label = parent_key)) +
+    treemapify::geom_treemap(color = "white") +
+    treemapify::geom_treemap_subgroup_border(color = "white") +
+    treemapify::geom_treemap_text(fontface = "italic", colour = "white",
+                                  alpha = 0.5, place = "centre", grow = TRUE) +
+    treemapify::geom_treemap_subgroup_text(place = "bottom", grow = TRUE, alpha = 1,
+                                           colour = "#333333", fontface = "italic", min.size = 0) +
     labs(fill = "") +
     scale_fill_brewer(palette = "Paired", type = "qual", direction = 1) +
-    # TODO: sort sorting for scale fill. Now based on factor's levels.
-    theme(legend.position="none")
-  
-  tags_treemap
+    theme(legend.position = "none")
 }
 
 ```
@@ -1077,32 +1210,100 @@ if (use_db) {
 ```{r}
 #| title: "Sources of information"
 
-df <- changesets |>
-  dplyr::transmute(
-    # force both to character and treat "" as NA
-    source = dplyr::na_if(as.character(source), ""),
-    imagery_used = dplyr::na_if(as.character(imagery_used), "")
+read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
+
+# Start from whatever is already in `changesets`
+src_tbl <- changesets |>
+  dplyr::select(
+    id,
+    imagery_used = dplyr::any_of("imagery_used"),
+    source      = dplyr::any_of("source")
   ) |>
-  dplyr::mutate(source = dplyr::coalesce(source, imagery_used)) |>
-  dplyr::filter(!is.na(source), nzchar(source)) |>
-  # split multi-valued sources like "Bing;Maxar"
-  tidyr::separate_rows(source, sep = ";") |>
+  # make sure both are character even if readr guessed <dbl>
   dplyr::mutate(
-    source = stringr::str_trim(source),
+    imagery_used = as.character(imagery_used),
+    source       = as.character(source)
+  )
+
+# If missing or all empty, backfill from RAW changesets.csv for the selected IDs
+if (!("imagery_used" %in% names(src_tbl) && "source" %in% names(src_tbl)) ||
+    nrow(src_tbl) == 0 ||
+    (all(is.na(src_tbl$imagery_used)) && all(is.na(src_tbl$source)))) {
+
+  raw_cs <- read_csv_if(file.path(data_root, "raw", "changesets.csv"))
+  if (!is.null(raw_cs) && "id" %in% names(raw_cs)) {
+    need_ids <- unique(na.omit(as.integer(changesets$id)))
+    raw_src <- raw_cs |>
+      dplyr::filter(.data$id %in% need_ids) |>
+      dplyr::transmute(
+        id,
+        imagery_used = as.character(dplyr::na_if(.data$imagery_used, "")),
+        source       = as.character(dplyr::na_if(.data$source, ""))
+      )
+    src_tbl <- dplyr::left_join(dplyr::select(changesets, id), raw_src, by = "id")
+  }
+}
+
+# Final fallback: derive from RAW tags if still empty
+if ((!"imagery_used" %in% names(src_tbl) && !"source" %in% names(src_tbl)) ||
+    (all(is.na(src_tbl$imagery_used)) && all(is.na(src_tbl$source)))) {
+
+  tags_raw <- read_csv_if(file.path(data_root, "raw", "changesets_tags.csv"))
+  if (is.null(tags_raw) || !nrow(tags_raw)) {
+    det <- read_csv_if(file.path(data_root, "raw", "changesets_details.csv"))
+    tags_raw <- if (!is.null(det) && nrow(det)) {
+      OSMdashboard::extract_and_combine_tags(det)
+    } else {
+      tibble::tibble(changeset=integer(), key=character(), value=character())
+    }
+  }
+
+  if (nrow(tags_raw)) {
+    need_ids <- unique(na.omit(as.integer(changesets$id)))
+    tag_src <- tags_raw |>
+      dplyr::filter(.data$changeset %in% need_ids,
+                    .data$key %in% c("imagery_used","imagery","source")) |>
+      dplyr::transmute(
+        id          = .data$changeset,
+        imagery_used = dplyr::if_else(.data$key %in% c("imagery_used","imagery"),
+                                      .data$value, NA_character_),
+        source       = dplyr::if_else(.data$key == "source",
+                                      .data$value, NA_character_)
+      ) |>
+      dplyr::group_by(id) |>
+      dplyr::summarise(
+        imagery_used = dplyr::first(stats::na.omit(imagery_used)),
+        source       = dplyr::first(stats::na.omit(source)),
+        .groups = "drop"
+      )
+    src_tbl <- dplyr::left_join(dplyr::select(changesets, id), tag_src, by = "id")
+  }
+}
+
+df <- src_tbl |>
+  dplyr::mutate(
+    imagery_used = as.character(dplyr::na_if(imagery_used, "")),
+    source       = as.character(dplyr::na_if(source, "")),
+    src          = dplyr::coalesce(imagery_used, source)  # prefer imagery_used when present
+  ) |>
+  dplyr::filter(!is.na(src), nzchar(src)) |>
+  tidyr::separate_rows(src, sep = "[;,]") |>
+  dplyr::mutate(
+    source = stringr::str_trim(src),
     source = stringr::str_replace_all(source, "\\+", " "),
     source = dplyr::case_when(
-      stringr::str_to_lower(source) == "survey" ~ "Survey",
+      stringr::str_to_lower(source) == "survey"                       ~ "Survey",
       stringr::str_detect(stringr::str_to_lower(source), "mapillary") ~ "Mapillary",
-      stringr::str_detect(stringr::str_to_lower(source), "esri") ~ "Esri World Imagery",
-      stringr::str_detect(source, "Bing") ~ "Bing Maps Aerial",
-      stringr::str_detect(source, "PNOA") ~ "PNOA Spain",
-      stringr::str_detect(source, "Maxar") ~ "Maxar Premium Imagery",
-      stringr::str_detect(source, "Catastro") ~ "Catastro Spain",
-      stringr::str_detect(source, "Strava") ~ "Strava Heat Map",
+      stringr::str_detect(stringr::str_to_lower(source), "esri")      ~ "Esri World Imagery",
+      stringr::str_detect(source, "Bing")                             ~ "Bing Maps Aerial",
+      stringr::str_detect(source, "PNOA")                             ~ "PNOA Spain",
+      stringr::str_detect(source, "Maxar")                            ~ "Maxar Premium Imagery",
+      stringr::str_detect(source, "Catastro")                         ~ "Catastro Spain",
+      stringr::str_detect(source, "Strava")                           ~ "Strava Heat Map",
       TRUE ~ source
     ),
     parent = dplyr::case_when(
-      stringr::str_detect(source, "Bing|Esri|Maxar|PNOA") ~ "Satellite Imagery",
+      stringr::str_detect(source, "Bing|Esri|Maxar|PNOA")                      ~ "Satellite Imagery",
       stringr::str_detect(stringr::str_to_lower(source), "imagery|copernicus") ~ "Satellite Imagery",
       TRUE ~ NA_character_
     )
@@ -1110,8 +1311,11 @@ df <- changesets |>
   dplyr::mutate(source = forcats::fct_lump_n(as.factor(source), 10)) |>
   dplyr::count(source, parent, sort = TRUE)
 
-plotly::plot_ly(df, type = "sunburst",
-                labels = ~source, values = ~n, parents = ~parent)
+if (!nrow(df)) {
+  cat("No source/imagery information recorded in the selected changesets.")
+} else {
+  plotly::plot_ly(df, type = "sunburst", labels = ~source, values = ~n, parents = ~parent)
+}
 
 
 ```
@@ -1120,85 +1324,120 @@ plotly::plot_ly(df, type = "sunburst",
 ```{r}
 #| title: "Software used"
 
-changesets |> 
-  select(created_by) |> 
-  rename(software = created_by) |> 
-  mutate(software_clean = case_when(
-    str_detect(software, "iD ") ~ "iD",
-    str_detect(software, "JOSM") ~ "JOSM",
-    str_detect(software, "maps.me") ~ "maps.me",
-    str_detect(software, "MapComplete") ~ "MapComplete",
-    str_detect(software, "Organic Maps") ~ "Organic Maps",
-    str_detect(software, "RapiD") ~ "RapiD",
-    str_detect(software, "StreetComplete") ~ "StreetComplete",
-    str_detect(software, "Vespucci") ~ "Vespucci",
-    .default = "Other"
-  )) |> 
-  count(software_clean, sort = TRUE) |> 
-  mutate(software_clean = fct_reorder(software_clean, n)) |> 
-  plot_ly(labels = ~software_clean, values = ~n) |> 
-  add_pie(hole = 0.6)
+read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
 
+cs_soft <- changesets
+
+# If `created_by` is missing or entirely empty in overlay, join from RAW for the selected IDs
+if (!("created_by" %in% names(cs_soft)) ||
+    all(is.na(cs_soft$created_by) | cs_soft$created_by == "")) {
+
+  raw_cs <- read_csv_if(file.path(data_root, "raw", "changesets.csv"))
+  if (!is.null(raw_cs) && nrow(raw_cs) && "id" %in% names(raw_cs)) {
+    need_ids <- unique(na.omit(as.integer(changesets$id)))
+    raw_soft <- raw_cs |>
+      dplyr::filter(.data$id %in% need_ids) |>
+      dplyr::transmute(id, created_by_raw = dplyr::na_if(as.character(.data$created_by), ""))
+
+    cs_soft <- cs_soft |>
+      dplyr::left_join(raw_soft, by = "id") |>
+      dplyr::mutate(created_by = dplyr::coalesce(.data$created_by, .data$created_by_raw)) |>
+      dplyr::select(-dplyr::ends_with("_raw"))
+  }
+}
+
+if (!("created_by" %in% names(cs_soft))) {
+  cat("No editor/software information available for the selected changesets.")
+} else {
+  cs_soft |>
+    dplyr::transmute(software = dplyr::na_if(as.character(.data$created_by), "")) |>
+    dplyr::filter(!is.na(.data$software)) |>
+    dplyr::mutate(
+      software_clean = dplyr::case_when(
+        stringr::str_detect(.data$software, "\\biD\\b")          ~ "iD",
+        stringr::str_detect(.data$software, "JOSM")              ~ "JOSM",
+        stringr::str_detect(stringr::str_to_lower(.data$software), "maps\\.me") ~ "maps.me",
+        stringr::str_detect(.data$software, "MapComplete")       ~ "MapComplete",
+        stringr::str_detect(.data$software, "Organic Maps")      ~ "Organic Maps",
+        stringr::str_detect(.data$software, "RapiD")             ~ "RapiD",
+        stringr::str_detect(.data$software, "StreetComplete")    ~ "StreetComplete",
+        stringr::str_detect(.data$software, "Vespucci")          ~ "Vespucci",
+        TRUE ~ "Other"
+      )
+    ) |>
+    dplyr::count(software_clean, sort = TRUE) |>
+    plotly::plot_ly(labels = ~software_clean, values = ~n) |>
+    plotly::add_pie(hole = 0.6)
+}
 
 ```
 
 ```{r}
 #| title: "Type of changesets"
 
-# Prefer actions from changesets_details if available; otherwise fall back,
-# and if nothing exists, show a friendly placeholder.
-if (exists("changesets_details") && "action" %in% names(changesets_details)) {
-  df_actions <- changesets_details |>
-    dplyr::count(action, sort = TRUE) |>
-    dplyr::rename(action_type = action)
-} else if ("action_type" %in% names(changesets_tags)) {
-  df_actions <- changesets_tags |>
-    dplyr::count(action_type, sort = TRUE)
+read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
+
+# 1) always load from RAW
+raw_cst <- read_csv_if(file.path(data_root, "raw", "changesets_tags.csv"))
+
+if (is.null(raw_cst) || !nrow(raw_cst)) {
+  cat("No raw changesets_tags.csv found.")
 } else {
-  df_actions <- tibble::tibble(action_type = "(not available)", n = 1L)
+  # 2) if we're using the overlay, keep only the selected IDs so it matches the rest of the dashboard
+  if (exists("changesets") && "id" %in% names(changesets)) {
+    sel_ids <- unique(na.omit(as.integer(changesets$id)))
+    if ("changeset" %in% names(raw_cst)) {
+      raw_cst <- dplyr::filter(raw_cst, .data$changeset %in% sel_ids)
+    }
+  }
+
+  # 3) prefer an existing 'action_type' column; otherwise bail cleanly
+  if (!"action_type" %in% names(raw_cst)) {
+    cat("No 'action_type' column in data/raw/changesets_tags.csv for the selected changesets.")
+  } else {
+    raw_cst |>
+      dplyr::filter(!is.na(.data$action_type), nzchar(.data$action_type)) |>
+      dplyr::count(action_type, sort = TRUE) |>
+      plotly::plot_ly(labels = ~action_type, values = ~n) |>
+      plotly::add_pie(hole = 0.6)
+  }
 }
 
-df_actions |>
-  plotly::plot_ly(labels = ~action_type, values = ~n) |>
-  plotly::add_pie(hole = 0.6)
 
 ```
 
 ```{r}
-#| title: Language
+#| title: "Language"
 
-get_language_counts <- function(changesets, changesets_tags) {
-  # Case 1: locale column present on changesets
-  if ("locale" %in% names(changesets) && any(!is.na(changesets$locale))) {
-    changesets |>
-      dplyr::select(locale) |>
-      tidyr::separate_wider_delim(
-        locale, delim = "-", names = c("language", "country"),
-        too_few = "align_start", cols_remove = FALSE
-      ) |>
-      dplyr::filter(!is.na(language), nzchar(language)) |>
-      dplyr::count(language, sort = TRUE)
-  # Case 2: try to recover from tags (locale/language keys)
-  } else if (exists("changesets_tags") &&
-             all(c("key","value") %in% names(changesets_tags)) &&
-             nrow(changesets_tags)) {
-    lang_by_tag <- changesets_tags |>
-      dplyr::filter(key %in% c("locale","language")) |>
-      dplyr::mutate(language = tolower(sub("-.*$", "", value))) |>
-      dplyr::filter(!is.na(language), nzchar(language)) |>
-      dplyr::count(language, sort = TRUE)
-    if (nrow(lang_by_tag)) lang_by_tag else tibble::tibble(language="(not available)", n=1L)
+read_csv_if <- function(p) if (file.exists(p)) readr::read_csv(p, show_col_types = FALSE) else NULL
+
+raw_cs <- read_csv_if(file.path(data_root, "raw", "changesets.csv"))
+
+if (is.null(raw_cs)) {
+  cat("No raw changesets.csv found.")
+} else {
+  # If overlay is active, keep only the selected IDs so counts match the rest of the dashboard
+  if (exists("changesets") && "id" %in% names(changesets)) {
+    sel_ids <- unique(na.omit(as.integer(changesets$id)))
+    raw_cs  <- dplyr::filter(raw_cs, .data$id %in% sel_ids)
+  }
+
+  lang_df <- raw_cs |>
+    dplyr::transmute(locale = dplyr::na_if(as.character(.data$locale), "")) |>
+    tidyr::separate(locale, into = c("language","country"),
+                    sep = "[-_]", remove = FALSE, extra = "drop", fill = "right") |>
+    dplyr::filter(!is.na(language), nzchar(language)) |>
+    dplyr::count(language, sort = TRUE) |>
+    dplyr::mutate(language = forcats::fct_reorder(language, n))
+
+  if (!nrow(lang_df)) {
+    cat("No locale information in raw changesets.")
   } else {
-    tibble::tibble(language="(not available)", n=1L)
+    plotly::plot_ly(lang_df, labels = ~language, values = ~n) |>
+      plotly::add_pie(hole = 0.6)
   }
 }
 
-lang_counts <- get_language_counts(changesets, changesets_tags)
-
-lang_counts |>
-  dplyr::mutate(language = forcats::fct_reorder(language, n)) |>
-  plotly::plot_ly(labels = ~language, values = ~n) |>
-  plotly::add_pie(hole = 0.6)
 
 ```
 

--- a/inst/templates/dashboard_groups/data/metadata/group_definition.csv
+++ b/inst/templates/dashboard_groups/data/metadata/group_definition.csv
@@ -1,0 +1,2 @@
+Group_name,Group_tags,Group_liketags,Group_comment,Group_likecomment,Group_bbx,Group_startdate,Group_enddate, TopActive
+Geochicas, geochicas,,,,,,,

--- a/inst/templates/dashboard_groups/data/metadata/group_definition.csv
+++ b/inst/templates/dashboard_groups/data/metadata/group_definition.csv
@@ -1,2 +1,2 @@
 Group_name,Group_tags,Group_liketags,Group_comment,Group_likecomment,Group_bbx,Group_startdate,Group_enddate,TopActive
-Geochicas,geochicas,,,,,,,4
+TeachOSM,,teachosm,,,,,,1000

--- a/inst/templates/dashboard_groups/data/metadata/group_definition.csv
+++ b/inst/templates/dashboard_groups/data/metadata/group_definition.csv
@@ -1,2 +1,2 @@
-Group_name,Group_tags,Group_liketags,Group_comment,Group_likecomment,Group_bbx,Group_startdate,Group_enddate, TopActive
-Geochicas, geochicas,,,,,,,
+Group_name,Group_tags,Group_liketags,Group_comment,Group_likecomment,Group_bbx,Group_startdate,Group_enddate,TopActive
+Geochicas,,,,,,,,10

--- a/inst/templates/dashboard_groups/data/metadata/group_definition.csv
+++ b/inst/templates/dashboard_groups/data/metadata/group_definition.csv
@@ -1,2 +1,2 @@
 Group_name,Group_tags,Group_liketags,Group_comment,Group_likecomment,Group_bbx,Group_startdate,Group_enddate,TopActive
-Geochicas,,,,,,,,10
+Geochicas,geochicas,,,,,,,4

--- a/inst/templates/dashboard_groups/data/metadata/group_info.csv
+++ b/inst/templates/dashboard_groups/data/metadata/group_info.csv
@@ -1,2 +1,2 @@
 name,description
-ExampleGroup,"Edit this line to provide context about this group, e.g.when was created, what’s their aim…"
+TeachOSM,This group is the top 1000 most active users that have used a hashtag containing the keyword 'teachosm'.

--- a/inst/templates/dashboard_groups/data/metadata/group_users.csv
+++ b/inst/templates/dashboard_groups/data/metadata/group_users.csv
@@ -1,2 +1,0 @@
-username
-example_username

--- a/inst/templates/dashboard_groups/data_retrieval.R
+++ b/inst/templates/dashboard_groups/data_retrieval.R
@@ -24,16 +24,43 @@ if (!"username" %in% names(group_users)) {
   stop("group_users.csv must have a 'username' column.")
 }
 
-# ---- CAP USERS TO 100 FOR NOW PLEASE CHANGE LATER -------------
-selected_users <- group_users$username |>
-  as.character() |>
-  trimws() |>
-  tolower()
+# --- if no users, exit nicely (and optionally write empty placeholders) ----
+selected_users <- unique(tolower(trimws(as.character(group_users$username))))
 selected_users <- selected_users[nzchar(selected_users)]
-selected_users <- unique(selected_users)
-selected_users <- head(selected_users, 100)   # <-- hard cap
 
-options(timeout = max(120, getOption("timeout")))
+if (length(selected_users) == 0) {
+  message("No users found for this group (from group_definition.csv). Nothing to fetch.")
+  # If you want to also create empty outputs so the dashboard can render:
+  dir.create(file.path(base_path,"data/raw"), recursive = TRUE, showWarnings = FALSE)
+  write.csv(data.frame(user=character(),
+                       map_changesets=integer(),
+                       map_notes=integer(),
+                       traces=integer(),
+                       diary=integer(),
+                       comments=integer(),
+                       date_creation=as.Date(character()),
+                       date_last_map_edit=as.Date(character())),
+            file.path(base_path,"data/raw/osm_user_details.csv"), row.names = FALSE)
+  write.csv(data.frame(id=integer(), user=character(), created=as.POSIXct(character()),
+                       min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()),
+            file.path(base_path,"data/raw/changesets.csv"), row.names = FALSE)
+  write.csv(data.frame(changeset=integer(), key=character(), value=character()),
+            file.path(base_path,"data/raw/changesets_tags.csv"), row.names = FALSE)
+  write.csv(data.frame(), file.path(base_path,"data/raw/changesets_details.csv"), row.names = FALSE)
+  write.csv(data.frame(user=character(), title=character(), timestamp=character()),
+            file.path(base_path,"data/raw/wiki_contributions.csv"), row.names = FALSE)
+  write.csv(data.frame(), file.path(base_path,"data/raw/contributions_diaries.csv"), row.names = FALSE)
+  write.csv(data.frame(user=character(), map_changesets=integer(), map_notes=integer(),
+                       traces=integer(), diary=integer(), comments=integer(),
+                       date_creation=as.Date(character()), date_last_map_edit=as.Date(character()),
+                       account_age=double(), map_activity_age=double(), wiki_edits=integer()),
+            file.path(base_path,"data/raw/contributions_summary.csv"), row.names = FALSE)
+  quit(save = "no", status = 0)
+}
+
+# ---- CAP USERS TO 100 FOR NOW -------------
+selected_users <- head(selected_users, 100)
+
 
 # ---------------------------------------
 # User profile stats polite to webpage and with caching

--- a/inst/templates/dashboard_groups/data_retrieval.R
+++ b/inst/templates/dashboard_groups/data_retrieval.R
@@ -1,88 +1,166 @@
 library(OSMdashboard)
 library(dplyr)
+library(purrr)
 library(lubridate)
 library(sf)
 
-
-# Retrieve data -----------------------------------------------------------
-
-# Add folder name if dashboard is not in the root of the project. Add trailing /
+# ---------------------------------------
+# Build group_users.csv from DB and group_definition.csv
+# ---------------------------------------
 base_path <- ""
 
-group_info <- read.csv(paste0(base_path, "data/metadata/group_info.csv"))
+system(paste(
+  "python",
+  "../python/extract_group_users_from_definition.py",
+  "--db", shQuote(paste0(base_path, "../database/osm_changesets.duckdb")),
+  "--group-def", shQuote(paste0(base_path, "data/metadata/group_definition.csv")),
+  "--out", shQuote(paste0(base_path, "data/metadata/group_users.csv"))
+))
+
+group_info  <- read.csv(paste0(base_path, "data/metadata/group_info.csv"))
 group_users <- read.csv(paste0(base_path, "data/metadata/group_users.csv"))
 
-selected_users <- group_users$username
+if (!"username" %in% names(group_users)) {
+  stop("group_users.csv must have a 'username' column.")
+}
 
-osm_user_details <- get_contributions_osm_users(selected_users)
+# ---- CAP USERS TO 100 FOR NOW PLEASE CHANGE LATER -------------
+selected_users <- group_users$username |>
+  as.character() |>
+  trimws() |>
+  tolower()
+selected_users <- selected_users[nzchar(selected_users)]
+selected_users <- unique(selected_users)
+selected_users <- head(selected_users, 100)   # <-- hard cap
 
-# Map contributions -------------------------------------------------------
+options(timeout = max(120, getOption("timeout")))
 
-changesets <- get_contributors_changesets(selected_users, 100)
+# ---------------------------------------
+# User profile stats polite to webpage and with caching
+# ---------------------------------------
+cache_dir <- file.path(base_path, "data/processed/.user_cache")
+dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+cache_path <- function(user) file.path(
+  cache_dir, paste0(gsub("[^A-Za-z0-9._-]", "_", user), ".rds")
+)
 
-changesets_details <- get_changesets_details(changesets$id)
+fetch_user_polite <- function(user, sleep_min = 0.6, sleep_max = 1.4) {
+  p <- cache_path(user)
+  if (file.exists(p)) return(readRDS(p))
+  Sys.sleep(runif(1, sleep_min, sleep_max))  # polite delay
+  res <- tryCatch(OSMdashboard::get_contributions_osm_users(user),
+                  error = function(e) NULL)
+  if (is.null(res) || nrow(res) == 0) return(NULL)
+  saveRDS(res, p)
+  res
+}
 
-changesets_tags <- extract_and_combine_tags(changesets_details)
+osm_user_details <- map_dfr(selected_users, fetch_user_polite)
 
+write.csv(osm_user_details, file = paste0(base_path,"data/raw/osm_user_details.csv"),
+  row.names = FALSE
+)
+
+# ---------------------------------------
+# Changesets (robust per-user)
+# ---------------------------------------
+safe_user_changesets <- function(user, n = 100) {
+  tryCatch(OSMdashboard::get_contributors_changesets(user, n),
+           error = function(e) NULL)
+}
+
+changesets <- map_dfr(selected_users, safe_user_changesets, n = 100)
+
+# if nothing came back, keep downstream from crashing
+if (nrow(changesets) == 0) {
+  changesets <- tibble::tibble(
+    id=integer(), user=character(), created=as.POSIXct(character()),
+    min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()
+  )
+}
+
+# Details in quiet batches
+ids <- unique(changesets$id)
+id_batches <- split(ids, ceiling(seq_along(ids)/200))
+changesets_details <- map_dfr(
+  id_batches,
+  ~ tryCatch(get_changesets_details(.x), error = function(e) NULL)
+)
+
+# Tags
+changesets_tags <- tryCatch(
+  extract_and_combine_tags(changesets_details),
+  error = function(e) tibble::tibble()
+)
+
+# ---------------------------------------
+# Write map contributions outputs
+# ---------------------------------------
 write.csv(changesets, file = paste0(base_path, "data/raw/changesets.csv"),
           row.names = FALSE)
 
-sf::st_write(changesets, dsn = paste0(base_path, "data/raw/changesets.gpkg"),
-             append = FALSE)
+if (nrow(changesets) > 0) {
+  sf::st_write(changesets, dsn = paste0(base_path, "data/raw/changesets.gpkg"),
+               append = FALSE, quiet = TRUE)
+}
 
 write.csv(changesets_tags,
-          file = paste0(base_path, "data/raw/changesets_tags.csv"))
+          file = paste0(base_path, "data/raw/changesets_tags.csv"),
+          row.names = FALSE)
 
 changesets_details |>
   dplyr::select(-tags, -members) |>
   write.csv(file = paste0(base_path, "data/raw/changesets_details.csv"),
             row.names = FALSE)
 
-
-# Wiki --------------------------------------------------------------------
-
-wiki_contributions <- get_contributions_wiki(selected_users) |>
-  select(-tags) |>
-  as_tibble()
+# ---------------------------------------
+# Wiki (robust, quiet)
+# ---------------------------------------
+wiki_contributions <- tryCatch(
+  get_contributions_wiki(selected_users) |>
+    dplyr::select(-tags) |>
+    tibble::as_tibble(),
+  error = function(e) tibble::tibble(user=character())
+)
 
 wiki_contributions_n <- wiki_contributions |>
   count(user) |>
   mutate(user = tolower(user)) |>
   rename(wiki_edits = n)
 
-write.csv(wiki_contributions, paste0(base_path, "data/raw/wiki_contributions.csv"),
-  row.names = FALSE
-)
+write.csv(wiki_contributions,
+          paste0(base_path, "data/raw/wiki_contributions.csv"),
+          row.names = FALSE)
 
-# Diaries -----------------------------------------------------------------
-
+# ---------------------------------------
+# Diaries (robust, quiet)
+# ---------------------------------------
 users_diaries <- osm_user_details |>
-  filter(diary > 0) |>
-  pull(user)
+  mutate(user = tolower(user)) |>
+  filter(!is.na(diary), diary > 0) |>
+  pull(user) |>
+  unique()
 
-contributions_diaries <- get_contributions_diaries(users_diaries)
+contributions_diaries <- tryCatch(
+  get_contributions_diaries(users_diaries),
+  error = function(e) tibble::tibble()
+)
 
 write.csv(contributions_diaries,
           paste0(base_path, "data/raw/contributions_diaries.csv"),
-          row.names = FALSE
-)
+          row.names = FALSE)
 
-
-# Contributions summary ---------------------------------------------------
-
+# ---------------------------------------
+# Contributions summary
+# ---------------------------------------
 contributions_summary <- osm_user_details |>
   mutate(
     user = tolower(user),
-    account_age = as.integer(
-      difftime(today(), date_creation, units = "days")
-    ) / 365,
-    map_activity_age = as.integer(
-      difftime(date_last_map_edit, date_creation, units = "days")
-    ) / 365
+    account_age = as.integer(difftime(today(), date_creation, units = "days")) / 365,
+    map_activity_age = as.integer(difftime(date_last_map_edit, date_creation, units = "days")) / 365
   ) |>
   left_join(wiki_contributions_n, by = "user")
 
 write.csv(contributions_summary,
-  paste0(base_path, "data/raw/contributions_summary.csv"),
-  row.names = FALSE
-)
+          paste0(base_path, "data/raw/contributions_summary.csv"),
+          row.names = FALSE)

--- a/inst/templates/dashboard_groups/data_retrieval.R
+++ b/inst/templates/dashboard_groups/data_retrieval.R
@@ -4,101 +4,113 @@ library(purrr)
 library(lubridate)
 library(sf)
 
-# ---------------------------------------
-# Build group_users.csv from DB and group_definition.csv
-# ---------------------------------------
-base_path <- ""
+# --------------------------------------------------
+# Base folders (run this script FROM example_dashboard)
+# --------------------------------------------------
+dash_dir  <- normalizePath(getwd(), winslash = "/")              # .../OSMdashboard/example_dashboard
+repo_root <- normalizePath(file.path(dash_dir, ".."), winslash = "/")  # .../OSMdashboard
 
-system(paste(
-  "python",
-  "../python/extract_group_users_from_definition.py",
-  "--db", shQuote(paste0(base_path, "../database/osm_changesets.duckdb")),
-  "--group-def", shQuote(paste0(base_path, "data/metadata/group_definition.csv")),
-  "--out", shQuote(paste0(base_path, "data/metadata/group_users.csv"))
-))
+# Tiny helper: build paths under example_dashboard
+P <- function(...) file.path(dash_dir, ...)
 
-group_info  <- read.csv(paste0(base_path, "data/metadata/group_info.csv"))
-group_users <- read.csv(paste0(base_path, "data/metadata/group_users.csv"))
+# --------------------------------------------------
+# Build group_users.csv from DB + group_definition.csv
+# --------------------------------------------------
+py_script <- file.path(repo_root, "python", "extract_group_users_from_definition.py")
+db_path   <- file.path(repo_root, "database", "osm_changesets.duckdb")
+group_def <- P("data", "metadata", "group_definition.csv")
+group_out <- P("data", "metadata", "group_users.csv")
+
+stopifnot("Python script not found"       = file.exists(py_script))
+stopifnot("DB not found"                  = file.exists(db_path))
+stopifnot("group_definition.csv missing"  = file.exists(group_def))
+dir.create(dirname(group_out), recursive = TRUE, showWarnings = FALSE)
+
+# Run Python safely
+status <- system2("python", c(py_script, "--db", db_path, "--group-def", group_def, "--out", group_out),
+                  stdout = TRUE, stderr = TRUE)
+cat(paste(status, collapse = "\n"))
+
+# --------------------------------------------------
+# Read metadata
+# --------------------------------------------------
+group_info  <- read.csv(P("data", "metadata", "group_info.csv"))
+group_users <- read.csv(P("data", "metadata", "group_users.csv"))
 
 if (!"username" %in% names(group_users)) {
   stop("group_users.csv must have a 'username' column.")
 }
 
-# --- if no users, exit nicely (and optionally write empty placeholders) ----
+# --------------------------------------------------
+# Selected users
+# --------------------------------------------------
 selected_users <- unique(tolower(trimws(as.character(group_users$username))))
 selected_users <- selected_users[nzchar(selected_users)]
-
 if (length(selected_users) == 0) {
   message("No users found for this group (from group_definition.csv). Nothing to fetch.")
-  # If you want to also create empty outputs so the dashboard can render:
-  dir.create(file.path(base_path,"data/raw"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(P("data","raw"), recursive = TRUE, showWarnings = FALSE)
+
   write.csv(data.frame(user=character(),
-                       map_changesets=integer(),
-                       map_notes=integer(),
-                       traces=integer(),
-                       diary=integer(),
-                       comments=integer(),
+                       map_changesets=integer(), map_notes=integer(), traces=integer(),
+                       diary=integer(), comments=integer(),
                        date_creation=as.Date(character()),
                        date_last_map_edit=as.Date(character())),
-            file.path(base_path,"data/raw/osm_user_details.csv"), row.names = FALSE)
+            P("data","raw","osm_user_details.csv"), row.names = FALSE)
+
   write.csv(data.frame(id=integer(), user=character(), created=as.POSIXct(character()),
                        min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()),
-            file.path(base_path,"data/raw/changesets.csv"), row.names = FALSE)
+            P("data","raw","changesets.csv"), row.names = FALSE)
+
   write.csv(data.frame(changeset=integer(), key=character(), value=character()),
-            file.path(base_path,"data/raw/changesets_tags.csv"), row.names = FALSE)
-  write.csv(data.frame(), file.path(base_path,"data/raw/changesets_details.csv"), row.names = FALSE)
+            P("data","raw","changesets_tags.csv"), row.names = FALSE)
+
+  write.csv(data.frame(), P("data","raw","changesets_details.csv"), row.names = FALSE)
+
   write.csv(data.frame(user=character(), title=character(), timestamp=character()),
-            file.path(base_path,"data/raw/wiki_contributions.csv"), row.names = FALSE)
-  write.csv(data.frame(), file.path(base_path,"data/raw/contributions_diaries.csv"), row.names = FALSE)
+            P("data","raw","wiki_contributions.csv"), row.names = FALSE)
+
+  write.csv(data.frame(), P("data","raw","contributions_diaries.csv"), row.names = FALSE)
+
   write.csv(data.frame(user=character(), map_changesets=integer(), map_notes=integer(),
                        traces=integer(), diary=integer(), comments=integer(),
                        date_creation=as.Date(character()), date_last_map_edit=as.Date(character()),
                        account_age=double(), map_activity_age=double(), wiki_edits=integer()),
-            file.path(base_path,"data/raw/contributions_summary.csv"), row.names = FALSE)
+            P("data","raw","contributions_summary.csv"), row.names = FALSE)
   quit(save = "no", status = 0)
 }
 
-# ---- CAP USERS TO 100 FOR NOW -------------
+# Cap
 selected_users <- head(selected_users, 100)
 
-
-# ---------------------------------------
-# User profile stats polite to webpage and with caching
-# ---------------------------------------
-cache_dir <- file.path(base_path, "data/processed/.user_cache")
+# --------------------------------------------------
+# User profile stats (with cache under example_dashboard/data/processed/.user_cache)
+# --------------------------------------------------
+cache_dir <- P("data", "processed", ".user_cache")
 dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
-cache_path <- function(user) file.path(
-  cache_dir, paste0(gsub("[^A-Za-z0-9._-]", "_", user), ".rds")
-)
+cache_path <- function(user) file.path(cache_dir, paste0(gsub("[^A-Za-z0-9._-]", "_", user), ".rds"))
 
 fetch_user_polite <- function(user, sleep_min = 0.6, sleep_max = 1.4) {
   p <- cache_path(user)
   if (file.exists(p)) return(readRDS(p))
-  Sys.sleep(runif(1, sleep_min, sleep_max))  # polite delay
-  res <- tryCatch(OSMdashboard::get_contributions_osm_users(user),
-                  error = function(e) NULL)
+  Sys.sleep(runif(1, sleep_min, sleep_max))
+  res <- tryCatch(OSMdashboard::get_contributions_osm_users(user), error = function(e) NULL)
   if (is.null(res) || nrow(res) == 0) return(NULL)
   saveRDS(res, p)
   res
 }
 
 osm_user_details <- map_dfr(selected_users, fetch_user_polite)
+write.csv(osm_user_details, P("data","raw","osm_user_details.csv"), row.names = FALSE)
 
-write.csv(osm_user_details, file = paste0(base_path,"data/raw/osm_user_details.csv"),
-  row.names = FALSE
-)
-
-# ---------------------------------------
-# Changesets (robust per-user)
-# ---------------------------------------
+# --------------------------------------------------
+# Changesets + details + tags
+# --------------------------------------------------
 safe_user_changesets <- function(user, n = 100) {
-  tryCatch(OSMdashboard::get_contributors_changesets(user, n),
-           error = function(e) NULL)
+  tryCatch(OSMdashboard::get_contributors_changesets(user, n), error = function(e) NULL)
 }
 
 changesets <- map_dfr(selected_users, safe_user_changesets, n = 100)
 
-# if nothing came back, keep downstream from crashing
 if (nrow(changesets) == 0) {
   changesets <- tibble::tibble(
     id=integer(), user=character(), created=as.POSIXct(character()),
@@ -106,7 +118,6 @@ if (nrow(changesets) == 0) {
   )
 }
 
-# Details in quiet batches
 ids <- unique(changesets$id)
 id_batches <- split(ids, ceiling(seq_along(ids)/200))
 changesets_details <- map_dfr(
@@ -114,58 +125,53 @@ changesets_details <- map_dfr(
   ~ tryCatch(get_changesets_details(.x), error = function(e) NULL)
 )
 
-# Tags
 changesets_tags <- tryCatch(
   extract_and_combine_tags(changesets_details),
   error = function(e) tibble::tibble()
 )
 
-# ---------------------------------------
-# Write map contributions outputs
-# ---------------------------------------
-write.csv(changesets, file = paste0(base_path, "data/raw/changesets.csv"),
-          row.names = FALSE)
+write.csv(changesets, P("data","raw","changesets.csv"), row.names = FALSE)
 
 if (nrow(changesets) > 0) {
-  sf::st_write(changesets, dsn = paste0(base_path, "data/raw/changesets.gpkg"),
-               append = FALSE, quiet = TRUE)
+  sf::st_write(changesets, dsn = P("data","raw","changesets.gpkg"), append = FALSE, quiet = TRUE)
 }
 
-write.csv(changesets_tags,
-          file = paste0(base_path, "data/raw/changesets_tags.csv"),
-          row.names = FALSE)
+write.csv(changesets_tags, P("data","raw","changesets_tags.csv"), row.names = FALSE)
 
-changesets_details |>
-  dplyr::select(-tags, -members) |>
-  write.csv(file = paste0(base_path, "data/raw/changesets_details.csv"),
-            row.names = FALSE)
+# Keep 'tags' in details; drop 'members' only
+details_out <- P("data","raw","changesets_details.csv")
+if (is.null(changesets_details) || !is.data.frame(changesets_details) || nrow(changesets_details) == 0) {
+  readr::write_csv(tibble::tibble(), details_out)
+} else {
+  changesets_details %>%
+    dplyr::select(-dplyr::any_of("members")) %>%
+    readr::write_csv(details_out)
+}
 
-# ---------------------------------------
-# Wiki (robust, quiet)
-# ---------------------------------------
+# --------------------------------------------------
+# Wiki
+# --------------------------------------------------
 wiki_contributions <- tryCatch(
-  get_contributions_wiki(selected_users) |>
-    dplyr::select(-tags) |>
+  get_contributions_wiki(selected_users) %>%
+    dplyr::select(-tags) %>%
     tibble::as_tibble(),
   error = function(e) tibble::tibble(user=character())
 )
 
-wiki_contributions_n <- wiki_contributions |>
-  count(user) |>
-  mutate(user = tolower(user)) |>
+wiki_contributions_n <- wiki_contributions %>%
+  count(user) %>%
+  mutate(user = tolower(user)) %>%
   rename(wiki_edits = n)
 
-write.csv(wiki_contributions,
-          paste0(base_path, "data/raw/wiki_contributions.csv"),
-          row.names = FALSE)
+write.csv(wiki_contributions, P("data","raw","wiki_contributions.csv"), row.names = FALSE)
 
-# ---------------------------------------
-# Diaries (robust, quiet)
-# ---------------------------------------
-users_diaries <- osm_user_details |>
-  mutate(user = tolower(user)) |>
-  filter(!is.na(diary), diary > 0) |>
-  pull(user) |>
+# --------------------------------------------------
+# Diaries
+# --------------------------------------------------
+users_diaries <- osm_user_details %>%
+  mutate(user = tolower(user)) %>%
+  filter(!is.na(diary), diary > 0) %>%
+  pull(user) %>%
   unique()
 
 contributions_diaries <- tryCatch(
@@ -173,21 +179,17 @@ contributions_diaries <- tryCatch(
   error = function(e) tibble::tibble()
 )
 
-write.csv(contributions_diaries,
-          paste0(base_path, "data/raw/contributions_diaries.csv"),
-          row.names = FALSE)
+write.csv(contributions_diaries, P("data","raw","contributions_diaries.csv"), row.names = FALSE)
 
-# ---------------------------------------
+# --------------------------------------------------
 # Contributions summary
-# ---------------------------------------
-contributions_summary <- osm_user_details |>
+# --------------------------------------------------
+contributions_summary <- osm_user_details %>%
   mutate(
     user = tolower(user),
-    account_age = as.integer(difftime(today(), date_creation, units = "days")) / 365,
+    account_age    = as.integer(difftime(today(), date_creation,      units = "days")) / 365,
     map_activity_age = as.integer(difftime(date_last_map_edit, date_creation, units = "days")) / 365
-  ) |>
+  ) %>%
   left_join(wiki_contributions_n, by = "user")
 
-write.csv(contributions_summary,
-          paste0(base_path, "data/raw/contributions_summary.csv"),
-          row.names = FALSE)
+write.csv(contributions_summary, P("data","raw","contributions_summary.csv"), row.names = FALSE)

--- a/inst/templates/dashboard_groups/data_retrieval.R
+++ b/inst/templates/dashboard_groups/data_retrieval.R
@@ -8,23 +8,31 @@ library(readr)
 library(stringr)
 library(tidyr)
 
-# ------------------------------
-# Param parsing (CLI + env)
-# ------------------------------
+# -------------------------------
+# Connection hygiene
+# -------------------------------
+on.exit(closeAllConnections(), add = TRUE)
 
-# Usage example:
-# Rscript data_retrieval.R \
-#   --use-db-overlay=true \
-#   --sample-perc-user=0.05 \
-#   --sample-max-total=0 \
-#   --seed=42
+safe_gc <- function() {
+  # If connections are building up, close them and GC
+  if (nrow(showConnections(all = TRUE)) > 100) closeAllConnections()
+  gc()
+}
 
+# base writer that avoids readr/gzfile path
+write_csv_base <- function(x, path) {
+  dir.create(dirname(path), showWarnings = FALSE, recursive = TRUE)
+  utils::write.csv(x, path, row.names = FALSE, na = "")
+}
+
+# ------------------------------
+# Param parsing
+# ------------------------------
 parse_num <- function(x, default) {
   if (is.null(x)) return(default)
   out <- suppressWarnings(as.numeric(x))
   if (is.na(out)) default else out
 }
-
 get_flag <- function(name, default = NULL) {
   args <- commandArgs(trailingOnly = TRUE)
   hit  <- args[grepl(paste0("^--", name, "="), args)]
@@ -49,10 +57,9 @@ parse_int <- function(x, default) {
 `%||%` <- function(a,b) if (is.null(a) || is.na(a)) b else a
 
 use_db_overlay   <- parse_bool(get_flag("use-db-overlay", "false"), FALSE)
-sample_perc_user  <- parse_num(get_flag("sample-perc-user", 0.05), 0.05)
-sample_max_total <- parse_int(get_flag("sample-max-total", 0), 0)  # 0 = no global cap
+sample_perc_user <- parse_num(get_flag("sample-perc-user", 0.05), 0.05)
+sample_max_total <- parse_int(get_flag("sample-max-total", 0), 0)
 seed_val         <- parse_int(get_flag("seed", 123), 123)
-
 set.seed(seed_val)
 
 cli_args <- commandArgs(trailingOnly = TRUE)
@@ -60,14 +67,14 @@ cat(
   "\n[params]\n",
   "  raw CLI args     : ", if (length(cli_args)) paste(cli_args, collapse = " ") else "(none)", "\n",
   "  use_db_overlay   : ", use_db_overlay, "\n",
-  "  sample_perc_user  : ", sample_perc_user, "\n",
+  "  sample_perc_user : ", sample_perc_user, "\n",
   "  sample_max_total : ", sample_max_total, "\n",
   "  seed             : ", seed_val, "\n\n",
   sep = ""
 )
 
 # --------------------------------------------------
-# Base folders (run this script from dashboard folder)
+# Base folders
 # --------------------------------------------------
 dash_dir  <- normalizePath(getwd(), winslash = "/")
 repo_root <- normalizePath(file.path(dash_dir, ".."), winslash = "/")
@@ -100,6 +107,22 @@ group_info  <- read.csv(P("data", "metadata", "group_info.csv"))
 group_users <- read.csv(P("data", "metadata", "group_users.csv"))
 if (!"username" %in% names(group_users)) stop("group_users.csv must have a 'username' column.")
 
+# Temporary Block-----------------------------------
+# target <- "mariefer"
+# group_users <- tryCatch({
+#   group_users <- dplyr::arrange(group_users, username)
+#   ix <- which(tolower(group_users$username) == tolower(target))
+#   if (length(ix) > 0) {
+#     to_drop <- ix:min(nrow(group_users), ix + 4)
+#     group_users <- group_users[-to_drop, , drop = FALSE]
+#   }
+#   group_users
+# }, error = function(e) {
+#   warning(paste("Error during user exclusion for target", target, ":", e$message))
+#   group_users
+# })
+#-------------------------------------------------------------
+
 # --------------------------------------------------
 # Selected users
 # --------------------------------------------------
@@ -109,39 +132,29 @@ selected_users <- selected_users[nzchar(selected_users)]
 if (!length(selected_users)) {
   message("No users found for this group. Writing empty RAW placeholders and exiting.")
   dir.create(P("data","raw"), recursive = TRUE, showWarnings = FALSE)
-
-  write.csv(data.frame(user=character(), map_changesets=integer(), map_notes=integer(),
-                       traces=integer(), diary=integer(), comments=integer(),
-                       date_creation=as.Date(character()), date_last_map_edit=as.Date(character())),
-            P("data","raw","osm_user_details.csv"), row.names = FALSE)
-
-  write.csv(data.frame(id=integer(), user=character(), created=as.POSIXct(character()),
-                       min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()),
-            P("data","raw","changesets.csv"), row.names = FALSE)
-
-  write.csv(data.frame(changeset=integer(), key=character(), value=character()),
-            P("data","raw","changesets_tags.csv"), row.names = FALSE)
-
-  readr::write_csv(tibble::tibble(), P("data","raw","changesets_details.csv"))
-
-  write.csv(data.frame(user=character(), title=character(), timestamp=character()),
-            P("data","raw","wiki_contributions.csv"), row.names = FALSE)
-
-  write.csv(data.frame(), P("data","raw","contributions_diaries.csv"), row.names = FALSE)
-
-  write.csv(data.frame(user=character(), map_changesets=integer(), map_notes=integer(),
-                       traces=integer(), diary=integer(), comments=integer(),
-                       date_creation=as.Date(character()), date_last_map_edit=as.Date(character()),
-                       account_age=double(), map_activity_age=double(), wiki_edits=integer()),
-            P("data","raw","contributions_summary.csv"), row.names = FALSE)
+  write_csv_base(data.frame(user=character(), map_changesets=integer(), map_notes=integer(),
+                            traces=integer(), diary=integer(), comments=integer(),
+                            date_creation=as.Date(character()), date_last_map_edit=as.Date(character())),
+                 P("data","raw","osm_user_details.csv"))
+  write_csv_base(data.frame(id=integer(), user=character(), created=as.POSIXct(character()),
+                            min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()),
+                 P("data","raw","changesets.csv"))
+  write_csv_base(data.frame(changeset=integer(), key=character(), value=character()),
+                 P("data","raw","changesets_tags.csv"))
+  write_csv_base(tibble::tibble(), P("data","raw","changesets_details.csv"))
+  write_csv_base(data.frame(user=character(), title=character(), timestamp=character()),
+                 P("data","raw","wiki_contributions.csv"))
+  write_csv_base(data.frame(), P("data","raw","contributions_diaries.csv"))
+  write_csv_base(data.frame(user=character(), map_changesets=integer(), map_notes=integer(),
+                            traces=integer(), diary=integer(), comments=integer(),
+                            date_creation=as.Date(character()), date_last_map_edit=as.Date(character()),
+                            account_age=double(), map_activity_age=double(), wiki_edits=integer()),
+                 P("data","raw","contributions_summary.csv"))
   quit(save = "no", status = 0)
 }
 
-# Soft cap to avoid API hammering
-selected_users <- head(selected_users, 100)
-
 # --------------------------------------------------
-# (A) Build DB overlay (when requested)
+# build DB overlay (when requested)
 # --------------------------------------------------
 overlay_dir <- P("data", "db_overlay")
 if (use_db_overlay) {
@@ -188,7 +201,7 @@ if (use_db_overlay) {
 }
 
 # --------------------------------------------------
-# (B) RAW: user profile stats
+# user profile stats
 # --------------------------------------------------
 cache_dir <- P("data", "processed", ".user_cache")
 dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
@@ -196,34 +209,57 @@ cache_path <- function(user) file.path(cache_dir, paste0(gsub("[^A-Za-z0-9._-]",
 
 fetch_user_polite <- function(user, sleep_min = 0.6, sleep_max = 1.4) {
   p <- cache_path(user)
-  if (file.exists(p)) return(readRDS(p))
+
+  # Read branch — open/close explicitly
+  if (file.exists(p)) {
+    con <- file(p, open = "rb")   # NOT gzfile
+    on.exit(try(close(con), silent = TRUE), add = TRUE)
+    out <- tryCatch(readRDS(con), error = function(e) NULL)
+    return(out)
+  }
+
+  # Write branch
   Sys.sleep(runif(1, sleep_min, sleep_max))
   res <- tryCatch(OSMdashboard::get_contributions_osm_users(user), error = function(e) NULL)
   if (is.null(res) || nrow(res) == 0) return(NULL)
-  saveRDS(res, p)
+
+  conw <- file(p, open = "wb")    # write uncompressed RDS
+  on.exit(try(close(conw), silent = TRUE), add = TRUE)
+  saveRDS(res, conw, compress = FALSE)
   res
 }
-osm_user_details <- map_dfr(selected_users, fetch_user_polite)
-write.csv(osm_user_details, P("data","raw","osm_user_details.csv"), row.names = FALSE)
+
+chunk <- function(x, k) split(x, ceiling(seq_along(x) / k))
+
+osm_user_details <- list()
+for (grp in chunk(selected_users, 20)) {           #a chunk of 20 users
+  part <- purrr::map_dfr(grp, fetch_user_polite)
+  osm_user_details[[length(osm_user_details) + 1]] <- part
+  closeAllConnections(); gc() #hard close between little chunks
+}
+osm_user_details <- dplyr::bind_rows(osm_user_details)
+
+write_csv_base(osm_user_details, P("data","raw","osm_user_details.csv"))
+safe_gc()
 
 # --------------------------------------------------
-# Helpers
+# helpers
 # --------------------------------------------------
 write_empty_changesets <- function() {
-  write.csv(
+  write_csv_base(
     data.frame(id=integer(), user=character(), created=as.POSIXct(character()),
                min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()),
-    P("data","raw","changesets.csv"), row.names = FALSE
+    P("data","raw","changesets.csv")
   )
-  write.csv(
+  write_csv_base(
     data.frame(changeset=integer(), key=character(), value=character()),
-    P("data","raw","changesets_tags.csv"), row.names = FALSE
+    P("data","raw","changesets_tags.csv")
   )
-  readr::write_csv(tibble::tibble(), P("data","raw","changesets_details.csv"))
+  write_csv_base(tibble::tibble(), P("data","raw","changesets_details.csv"))
 }
 
 # --------------------------------------------------
-# (C) RAW: changesets / tags / details
+# changesets/tags/ details
 # --------------------------------------------------
 if (!use_db_overlay) {
   # ---------- BASELINE: API flow per user ---------------
@@ -231,6 +267,38 @@ if (!use_db_overlay) {
     tryCatch(OSMdashboard::get_contributors_changesets(user, n), error = function(e) NULL)
   }
   changesets <- map_dfr(selected_users, safe_user_changesets, n = 100)
+  safe_gc()
+
+  ids <- unique(changesets$id)
+  id_batches <- split(ids, ceiling(seq_along(ids)/200))
+
+  changesets_details <- purrr::map_dfr(
+    id_batches,
+    function(ids) {
+      out <- tryCatch(get_changesets_details(ids), error = function(e) NULL)
+      safe_gc()
+      out
+    }
+  )
+
+  if (nrow(changesets) > 0 && nrow(changesets_details) > 0) {
+    changesets <- changesets |>
+      dplyr::left_join(
+        changesets_details |> dplyr::select(id, lat, lon),
+        by = "id"
+      )
+  }
+
+  if (all(c("lat", "lon") %in% names(changesets)) &&
+      !all(c("min_lat", "min_lon", "max_lat", "max_lon") %in% names(changesets))) {
+    changesets <- changesets |>
+      dplyr::mutate(
+        min_lat = .data$lat,
+        max_lat = .data$lat,
+        min_lon = .data$lon,
+        max_lon = .data$lon
+      )
+  }
 
   if (nrow(changesets) == 0) {
     changesets <- tibble::tibble(
@@ -239,68 +307,59 @@ if (!use_db_overlay) {
     )
   }
 
-  ids <- unique(changesets$id)
-  id_batches <- split(ids, ceiling(seq_along(ids)/200))
-  changesets_details <- map_dfr(
-    id_batches,
-    ~ tryCatch(get_changesets_details(.x), error = function(e) NULL)
-  )
-
-  # >>> IMPORTANT: derive tags BEFORE writing details (list-cols vanish in CSV)
+  # derive tags BEFORE writing details
   changesets_tags <- tryCatch(
     extract_and_combine_tags(changesets_details),
     error = function(e) tibble::tibble(changeset = integer(), key = character(), value = character())
   )
-  readr::write_csv(changesets_tags, P("data","raw","changesets_tags.csv"))
+  write_csv_base(changesets_tags, P("data","raw","changesets_tags.csv"))
+  safe_gc()
 
-  # Write details (without list-cols)
+  # locale from tags (optional)
+  locale_df <- changesets_tags |>
+    dplyr::filter(key == "locale") |>
+    dplyr::group_by(changeset) |>
+    dplyr::summarise(locale = dplyr::first(stats::na.omit(value)), .groups = "drop") |>
+    dplyr::rename(id = changeset)
+
+  changesets <- changesets |>
+    dplyr::left_join(locale_df, by = "id") |>
+    dplyr::mutate(locale = as.character(locale))
+
   details_out <- changesets_details %>% dplyr::select(-dplyr::any_of(c("members","tags","tags_df")))
-  readr::write_csv(details_out, P("data","raw","changesets_details.csv"))
+  write_csv_base(details_out, P("data","raw","changesets_details.csv"))
+  write_csv_base(changesets,   P("data","raw","changesets.csv"))
+  safe_gc()
 
-  # Write changesets as returned by API
-  write.csv(changesets, P("data","raw","changesets.csv"), row.names = FALSE)
-
-  # Optional GPKG (keep if you still want it)
   if (nrow(changesets) > 0) {
     suppressWarnings(sf::st_write(changesets, dsn = P("data","raw","changesets.gpkg"),
                                   append = FALSE, quiet = TRUE))
   }
+  safe_gc()
 
 } else {
-  # ---------- OVERLAY SAMPLING: sample IDs, then API details  ----------
-  cs_overlay  <- P("data","db_overlay","changesets_subset.csv")
+  # ---------- OVERLAY SAMPLING: sample IDs, then API details ----------
+  cs_overlay <- P("data","db_overlay","changesets_subset.csv")
   if (!file.exists(cs_overlay)) {
     warning("Overlay changesets_subset.csv not found; writing empty RAW and continuing.")
     write_empty_changesets()
   } else {
-    # Load overlay rows and normalise user column
     cs_all <- readr::read_csv(cs_overlay, show_col_types = FALSE)
     if (!"user" %in% names(cs_all) && "username" %in% names(cs_all)) {
       cs_all <- dplyr::rename(cs_all, user = username)
     }
     cs_all <- cs_all |> dplyr::mutate(user = tolower(user))
 
-    # ---- per-user targets ----
     per_user_n <- cs_all |> dplyr::count(user, name = "n_total")
     alloc <- per_user_n
-
-    # --- NEW: Calculate target based on percentage (n_total * percentage) ---
     alloc$n_target_raw <- ceiling(alloc$n_total * sample_perc_user)
 
     if (sample_max_total > 0) {
-      # Use the proportionally calculated size as the effective 'per user cap'
       user_cap <- alloc$n_target_raw
-
-      # Now, scale down the proportional targets if the total exceeds sample_max_total
       w <- alloc$n_target_raw / sum(alloc$n_target_raw)
       prop_n <- pmax(1L, floor(w * sample_max_total))
-
-      # The target is the proportional calculation, capped by the overall max_total constraint
       alloc$n_target <- pmin(prop_n, user_cap)
-
       overflow <- sum(alloc$n_target) - sample_max_total
-
-      # The complex overflow logic remains (simplified slightly here):
       if (overflow > 0) {
         ord <- order(alloc$n_target, decreasing = TRUE)
         i <- 1L
@@ -316,7 +375,6 @@ if (!use_db_overlay) {
         }
       }
     } else {
-      # No global cap: n_target is simply the proportional calculation
       alloc$n_target <- alloc$n_target_raw
     }
 
@@ -328,7 +386,6 @@ if (!use_db_overlay) {
     cat(sprintf("[sampling] users in overlay: %d | with target > 0: %d | total target: %d\n",
                 dplyr::n_distinct(cs_all$user), nrow(alloc), sum(alloc$n_target)))
 
-    # ---- sample overlay rows per user -> IDs only ----
     set.seed(seed_val)
     sampled <- cs_all %>%
       dplyr::inner_join(alloc, by = "user") %>%
@@ -340,28 +397,30 @@ if (!use_db_overlay) {
       dplyr::ungroup() %>%
       dplyr::select(-.rand, -.row)
 
-    # ---- fetch API details only for sampled IDs ----
     sel_ids <- unique(na.omit(as.integer(sampled$id)))
     if (!length(sel_ids)) {
       write_empty_changesets()
     } else {
       id_batches <- split(sel_ids, ceiling(seq_along(sel_ids)/200))
-      changesets_details <- map_dfr(id_batches, ~ tryCatch(get_changesets_details(.x), error = function(e) NULL))
+      changesets_details <- purrr::map_dfr(
+        id_batches,
+        function(ids) {
+          out <- tryCatch(get_changesets_details(ids), error = function(e) NULL)
+          safe_gc()
+          out
+        }
+      )
 
       if (is.null(changesets_details) || !is.data.frame(changesets_details) || !nrow(changesets_details)) {
         write_empty_changesets()
       } else {
-        #derive tags BEFORE writing details
-
         tags_df <- OSMdashboard::extract_and_combine_tags(changesets_details)
+        write_csv_base(tags_df, P("data","raw","changesets_tags.csv"))
+        safe_gc()
 
-        readr::write_csv(tags_df, P("data","raw","changesets_tags.csv"))
-
-        # Write details (strip list-cols)
         details_clean <- changesets_details %>% dplyr::select(-dplyr::any_of(c("members","tags","tags_df")))
-        readr::write_csv(details_clean, P("data","raw","changesets_details.csv"))
+        write_csv_base(details_clean, P("data","raw","changesets_details.csv"))
 
-        # Build changesets.csv from API details + tags
         det <- tibble::as_tibble(changesets_details)
         n   <- nrow(det)
         col_or_na <- function(df, nm, n) if (nm %in% names(df)) df[[nm]] else rep(NA, n)
@@ -387,30 +446,30 @@ if (!use_db_overlay) {
           comment    = as.character(col_or_na(det, "comment", n))
         ) %>% dplyr::distinct()
 
-        # Join locale/hashtags from tags
         tags_wide <- if (nrow(tags_df)) {
           tags_df %>%
-            dplyr::filter(key %in% c("locale","hashtags", "imagery")) %>%
+            dplyr::filter(key %in% c("hashtags", "imagery")) %>%
             dplyr::group_by(changeset, key) %>%
             dplyr::summarise(value = dplyr::first(stats::na.omit(value)), .groups = "drop") %>%
             tidyr::pivot_wider(names_from = key, values_from = value) %>%
             dplyr::rename(id = changeset) %>%
-            # convert ID to an integer
             dplyr::mutate(id = as.integer(id))
         } else {
-          tibble::tibble(id = integer(), locale = character(), hashtags = character())
+          tibble::tibble(id = integer(), hashtags = character(), imagery = character())
         }
 
         core <- core %>%
           dplyr::left_join(tags_wide, by = "id") %>%
-          #Fill with NA if join fails
           dplyr::mutate(
-            locale = if("locale" %in% names(.)) as.character(locale) else NA_character_,
-            hashtags = if("hashtags" %in% names(.)) as.character(hashtags) else NA_character_,
-            imagery = if("imagery" %in% names(.)) as.character(imagery) else NA_character_
+            hashtags = if ("hashtags" %in% names(.)) as.character(hashtags) else NA_character_,
+            imagery  = if ("imagery"  %in% names(.)) as.character(imagery)  else NA_character_
           )
 
-        # Fill bbox from overlay if API missed it
+        locale_overlay <- sampled %>% dplyr::select(id, dplyr::any_of(c("locale")))
+        core <- core %>%
+          dplyr::left_join(locale_overlay, by = "id") %>%
+          dplyr::mutate(locale = if ("locale" %in% names(.)) as.character(locale) else NA_character_)
+
         bbox_overlay <- sampled %>% dplyr::select(id, dplyr::any_of(c("min_lat","min_lon","max_lat","max_lon")))
         if (nrow(bbox_overlay)) {
           core <- core %>%
@@ -424,14 +483,15 @@ if (!use_db_overlay) {
             dplyr::select(-dplyr::ends_with("_ov"))
         }
 
-        readr::write_csv(core, P("data","raw","changesets.csv"))
+        write_csv_base(core, P("data","raw","changesets.csv"))
+        safe_gc()
       }
     }
   }
 }
 
 # --------------------------------------------------
-# (D) RAW: Wiki
+# Wiki
 # --------------------------------------------------
 wiki_contributions <- tryCatch(
   get_contributions_wiki(selected_users) %>%
@@ -441,10 +501,11 @@ wiki_contributions <- tryCatch(
 )
 wiki_contributions_n <- wiki_contributions %>%
   count(user) %>% mutate(user = tolower(user)) %>% rename(wiki_edits = n)
-write.csv(wiki_contributions, P("data","raw","wiki_contributions.csv"), row.names = FALSE)
+write_csv_base(wiki_contributions, P("data","raw","wiki_contributions.csv"))
+safe_gc()
 
 # --------------------------------------------------
-# (E) RAW: Diaries
+# Diaries
 # --------------------------------------------------
 users_diaries <- osm_user_details %>%
   mutate(user = tolower(user)) %>%
@@ -453,10 +514,11 @@ users_diaries <- osm_user_details %>%
   unique()
 contributions_diaries <- tryCatch(get_contributions_diaries(users_diaries),
                                   error = function(e) tibble::tibble())
-write.csv(contributions_diaries, P("data","raw","contributions_diaries.csv"), row.names = FALSE)
+write_csv_base(contributions_diaries, P("data","raw","contributions_diaries.csv"))
+safe_gc()
 
 # --------------------------------------------------
-# (F) RAW: Contributions summary
+# Contributions summary
 # --------------------------------------------------
 contributions_summary <- osm_user_details %>%
   mutate(
@@ -465,4 +527,5 @@ contributions_summary <- osm_user_details %>%
     map_activity_age = as.integer(difftime(date_last_map_edit, date_creation, units = "days")) / 365
   ) %>%
   left_join(wiki_contributions_n, by = "user")
-write.csv(contributions_summary, P("data","raw","contributions_summary.csv"), row.names = FALSE)
+write_csv_base(contributions_summary, P("data","raw","contributions_summary.csv"))
+safe_gc()

--- a/inst/templates/dashboard_groups/data_retrieval.R
+++ b/inst/templates/dashboard_groups/data_retrieval.R
@@ -1,34 +1,96 @@
+# data_retrieval.R
 library(OSMdashboard)
 library(dplyr)
 library(purrr)
 library(lubridate)
 library(sf)
+library(readr)
+library(stringr)
+library(tidyr)
+
+# ------------------------------
+# Param parsing (CLI + env)
+# ------------------------------
+
+# Usage example:
+# Rscript data_retrieval.R \
+#   --use-db-overlay=true \
+#   --sample-perc-user=0.05 \
+#   --sample-max-total=0 \
+#   --seed=42
+
+parse_num <- function(x, default) {
+  if (is.null(x)) return(default)
+  out <- suppressWarnings(as.numeric(x))
+  if (is.na(out)) default else out
+}
+
+get_flag <- function(name, default = NULL) {
+  args <- commandArgs(trailingOnly = TRUE)
+  hit  <- args[grepl(paste0("^--", name, "="), args)]
+  if (length(hit)) {
+    val <- sub(paste0("^--", name, "="), "", hit[1])
+  } else {
+    envn <- toupper(gsub("-", "_", name))
+    val  <- Sys.getenv(envn, unset = NA)
+  }
+  if (is.na(val) || val == "") return(default)
+  val
+}
+parse_bool <- function(x, default = FALSE) {
+  if (is.null(x)) return(default)
+  tolower(x) %in% c("1","true","t","yes","y")
+}
+parse_int <- function(x, default) {
+  if (is.null(x)) return(default)
+  out <- suppressWarnings(as.integer(x))
+  if (is.na(out)) default else out
+}
+`%||%` <- function(a,b) if (is.null(a) || is.na(a)) b else a
+
+use_db_overlay   <- parse_bool(get_flag("use-db-overlay", "false"), FALSE)
+sample_perc_user  <- parse_num(get_flag("sample-perc-user", 0.05), 0.05)
+sample_max_total <- parse_int(get_flag("sample-max-total", 0), 0)  # 0 = no global cap
+seed_val         <- parse_int(get_flag("seed", 123), 123)
+
+set.seed(seed_val)
+
+cli_args <- commandArgs(trailingOnly = TRUE)
+cat(
+  "\n[params]\n",
+  "  raw CLI args     : ", if (length(cli_args)) paste(cli_args, collapse = " ") else "(none)", "\n",
+  "  use_db_overlay   : ", use_db_overlay, "\n",
+  "  sample_perc_user  : ", sample_perc_user, "\n",
+  "  sample_max_total : ", sample_max_total, "\n",
+  "  seed             : ", seed_val, "\n\n",
+  sep = ""
+)
 
 # --------------------------------------------------
-# Base folders (run this script FROM example_dashboard)
+# Base folders (run this script from dashboard folder)
 # --------------------------------------------------
-dash_dir  <- normalizePath(getwd(), winslash = "/")              # .../OSMdashboard/example_dashboard
-repo_root <- normalizePath(file.path(dash_dir, ".."), winslash = "/")  # .../OSMdashboard
-
-# Tiny helper: build paths under example_dashboard
+dash_dir  <- normalizePath(getwd(), winslash = "/")
+repo_root <- normalizePath(file.path(dash_dir, ".."), winslash = "/")
 P <- function(...) file.path(dash_dir, ...)
 
 # --------------------------------------------------
 # Build group_users.csv from DB + group_definition.csv
 # --------------------------------------------------
-py_script <- file.path(repo_root, "python", "extract_group_users_from_definition.py")
-db_path   <- file.path(repo_root, "database", "osm_changesets.duckdb")
-group_def <- P("data", "metadata", "group_definition.csv")
-group_out <- P("data", "metadata", "group_users.csv")
+py_extract  <- file.path(repo_root, "python", "extract_group_users_from_definition.py")
+duckdb_path <- file.path(repo_root, "database", "osm_changesets.duckdb")
+group_def   <- P("data", "metadata", "group_definition.csv")
+group_out   <- P("data", "metadata", "group_users.csv")
 
-stopifnot("Python script not found"       = file.exists(py_script))
-stopifnot("DB not found"                  = file.exists(db_path))
-stopifnot("group_definition.csv missing"  = file.exists(group_def))
+stopifnot("Python extract script not found" = file.exists(py_extract))
+stopifnot("DuckDB not found"                = file.exists(duckdb_path))
+stopifnot("group_definition.csv missing"    = file.exists(group_def))
 dir.create(dirname(group_out), recursive = TRUE, showWarnings = FALSE)
 
-# Run Python safely
-status <- system2("python", c(py_script, "--db", db_path, "--group-def", group_def, "--out", group_out),
-                  stdout = TRUE, stderr = TRUE)
+status <- system2(
+  "python",
+  c(py_extract, "--db", duckdb_path, "--group-def", group_def, "--out", group_out),
+  stdout = TRUE, stderr = TRUE
+)
 cat(paste(status, collapse = "\n"))
 
 # --------------------------------------------------
@@ -36,25 +98,21 @@ cat(paste(status, collapse = "\n"))
 # --------------------------------------------------
 group_info  <- read.csv(P("data", "metadata", "group_info.csv"))
 group_users <- read.csv(P("data", "metadata", "group_users.csv"))
-
-if (!"username" %in% names(group_users)) {
-  stop("group_users.csv must have a 'username' column.")
-}
+if (!"username" %in% names(group_users)) stop("group_users.csv must have a 'username' column.")
 
 # --------------------------------------------------
 # Selected users
 # --------------------------------------------------
-selected_users <- unique(tolower(trimws(as.character(group_users$username))))
+selected_users <- group_users$username |> as.character() |> trimws() |> tolower() |> unique()
 selected_users <- selected_users[nzchar(selected_users)]
-if (length(selected_users) == 0) {
-  message("No users found for this group (from group_definition.csv). Nothing to fetch.")
+
+if (!length(selected_users)) {
+  message("No users found for this group. Writing empty RAW placeholders and exiting.")
   dir.create(P("data","raw"), recursive = TRUE, showWarnings = FALSE)
 
-  write.csv(data.frame(user=character(),
-                       map_changesets=integer(), map_notes=integer(), traces=integer(),
-                       diary=integer(), comments=integer(),
-                       date_creation=as.Date(character()),
-                       date_last_map_edit=as.Date(character())),
+  write.csv(data.frame(user=character(), map_changesets=integer(), map_notes=integer(),
+                       traces=integer(), diary=integer(), comments=integer(),
+                       date_creation=as.Date(character()), date_last_map_edit=as.Date(character())),
             P("data","raw","osm_user_details.csv"), row.names = FALSE)
 
   write.csv(data.frame(id=integer(), user=character(), created=as.POSIXct(character()),
@@ -64,7 +122,7 @@ if (length(selected_users) == 0) {
   write.csv(data.frame(changeset=integer(), key=character(), value=character()),
             P("data","raw","changesets_tags.csv"), row.names = FALSE)
 
-  write.csv(data.frame(), P("data","raw","changesets_details.csv"), row.names = FALSE)
+  readr::write_csv(tibble::tibble(), P("data","raw","changesets_details.csv"))
 
   write.csv(data.frame(user=character(), title=character(), timestamp=character()),
             P("data","raw","wiki_contributions.csv"), row.names = FALSE)
@@ -79,11 +137,58 @@ if (length(selected_users) == 0) {
   quit(save = "no", status = 0)
 }
 
-# Cap
+# Soft cap to avoid API hammering
 selected_users <- head(selected_users, 100)
 
 # --------------------------------------------------
-# User profile stats (with cache under example_dashboard/data/processed/.user_cache)
+# (A) Build DB overlay (when requested)
+# --------------------------------------------------
+overlay_dir <- P("data", "db_overlay")
+if (use_db_overlay) {
+  overlay_py <- file.path(repo_root, "python", "overlay.py")
+  queries_py <- file.path(repo_root, "python", "queries.py")
+
+  stopifnot("overlay.py not found" = file.exists(overlay_py))
+  stopifnot("queries.py not found" = file.exists(queries_py))
+  dir.create(overlay_dir, recursive = TRUE, showWarnings = FALSE)
+
+  cat("\n[overlay] Building DB overlay...\n",
+      "  overlay.py  : ", overlay_py, "\n",
+      "  queries.py  : ", queries_py, "\n",
+      "  duckdb      : ", duckdb_path, "\n",
+      "  group_users : ", P("data","metadata","group_users.csv"), "\n",
+      "  group_info  : ", P("data","metadata","group_info.csv"), "\n",
+      "  out_dir     : ", overlay_dir, "\n\n", sep = "")
+
+  py_tmp <- tempfile(fileext = ".py")
+  py_code <- sprintf(
+    paste0(
+      "import importlib.util\n",
+      "p=r'''%s'''\nq=r'''%s'''\n",
+      "spec=importlib.util.spec_from_file_location('overlay', p)\n",
+      "m=importlib.util.module_from_spec(spec)\n",
+      "spec.loader.exec_module(m)\n",
+      "m.build_overlay(db_path=r'''%s''', queries_path=q,\n",
+      "  group_users_csv=r'''%s''', group_info_csv=r'''%s''', out_dir=r'''%s''',\n",
+      "  usernames=None, hashtags=None, start=None, end=None, bbox=None)\n"
+    ),
+    overlay_py, queries_py, duckdb_path,
+    P("data","metadata","group_users.csv"),
+    P("data","metadata","group_info.csv"),
+    overlay_dir
+  )
+  writeLines(py_code, py_tmp)
+  out <- tryCatch(system2("python", c(py_tmp), stdout = TRUE, stderr = TRUE),
+                  error = function(e) structure(list(error = e$message), class = "overlay_error"))
+  cat("[overlay] Python output:\n", paste(out, collapse = "\n"), "\n", sep = "")
+  unlink(py_tmp)
+
+  expected <- file.path(overlay_dir, "changesets_subset.csv")
+  if (!file.exists(expected)) warning("Overlay build did not produce ", expected, ".")
+}
+
+# --------------------------------------------------
+# (B) RAW: user profile stats
 # --------------------------------------------------
 cache_dir <- P("data", "processed", ".user_cache")
 dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
@@ -98,58 +203,235 @@ fetch_user_polite <- function(user, sleep_min = 0.6, sleep_max = 1.4) {
   saveRDS(res, p)
   res
 }
-
 osm_user_details <- map_dfr(selected_users, fetch_user_polite)
 write.csv(osm_user_details, P("data","raw","osm_user_details.csv"), row.names = FALSE)
 
 # --------------------------------------------------
-# Changesets + details + tags
+# Helpers
 # --------------------------------------------------
-safe_user_changesets <- function(user, n = 100) {
-  tryCatch(OSMdashboard::get_contributors_changesets(user, n), error = function(e) NULL)
-}
-
-changesets <- map_dfr(selected_users, safe_user_changesets, n = 100)
-
-if (nrow(changesets) == 0) {
-  changesets <- tibble::tibble(
-    id=integer(), user=character(), created=as.POSIXct(character()),
-    min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()
+write_empty_changesets <- function() {
+  write.csv(
+    data.frame(id=integer(), user=character(), created=as.POSIXct(character()),
+               min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()),
+    P("data","raw","changesets.csv"), row.names = FALSE
   )
-}
-
-ids <- unique(changesets$id)
-id_batches <- split(ids, ceiling(seq_along(ids)/200))
-changesets_details <- map_dfr(
-  id_batches,
-  ~ tryCatch(get_changesets_details(.x), error = function(e) NULL)
-)
-
-changesets_tags <- tryCatch(
-  extract_and_combine_tags(changesets_details),
-  error = function(e) tibble::tibble()
-)
-
-write.csv(changesets, P("data","raw","changesets.csv"), row.names = FALSE)
-
-if (nrow(changesets) > 0) {
-  sf::st_write(changesets, dsn = P("data","raw","changesets.gpkg"), append = FALSE, quiet = TRUE)
-}
-
-write.csv(changesets_tags, P("data","raw","changesets_tags.csv"), row.names = FALSE)
-
-# Keep 'tags' in details; drop 'members' only
-details_out <- P("data","raw","changesets_details.csv")
-if (is.null(changesets_details) || !is.data.frame(changesets_details) || nrow(changesets_details) == 0) {
-  readr::write_csv(tibble::tibble(), details_out)
-} else {
-  changesets_details %>%
-    dplyr::select(-dplyr::any_of("members")) %>%
-    readr::write_csv(details_out)
+  write.csv(
+    data.frame(changeset=integer(), key=character(), value=character()),
+    P("data","raw","changesets_tags.csv"), row.names = FALSE
+  )
+  readr::write_csv(tibble::tibble(), P("data","raw","changesets_details.csv"))
 }
 
 # --------------------------------------------------
-# Wiki
+# (C) RAW: changesets / tags / details
+# --------------------------------------------------
+if (!use_db_overlay) {
+  # ---------- BASELINE: API flow per user ---------------
+  safe_user_changesets <- function(user, n = 100) {
+    tryCatch(OSMdashboard::get_contributors_changesets(user, n), error = function(e) NULL)
+  }
+  changesets <- map_dfr(selected_users, safe_user_changesets, n = 100)
+
+  if (nrow(changesets) == 0) {
+    changesets <- tibble::tibble(
+      id=integer(), user=character(), created=as.POSIXct(character()),
+      min_lat=double(), min_lon=double(), max_lat=double(), max_lon=double()
+    )
+  }
+
+  ids <- unique(changesets$id)
+  id_batches <- split(ids, ceiling(seq_along(ids)/200))
+  changesets_details <- map_dfr(
+    id_batches,
+    ~ tryCatch(get_changesets_details(.x), error = function(e) NULL)
+  )
+
+  # >>> IMPORTANT: derive tags BEFORE writing details (list-cols vanish in CSV)
+  changesets_tags <- tryCatch(
+    extract_and_combine_tags(changesets_details),
+    error = function(e) tibble::tibble(changeset = integer(), key = character(), value = character())
+  )
+  readr::write_csv(changesets_tags, P("data","raw","changesets_tags.csv"))
+
+  # Write details (without list-cols)
+  details_out <- changesets_details %>% dplyr::select(-dplyr::any_of(c("members","tags","tags_df")))
+  readr::write_csv(details_out, P("data","raw","changesets_details.csv"))
+
+  # Write changesets as returned by API
+  write.csv(changesets, P("data","raw","changesets.csv"), row.names = FALSE)
+
+  # Optional GPKG (keep if you still want it)
+  if (nrow(changesets) > 0) {
+    suppressWarnings(sf::st_write(changesets, dsn = P("data","raw","changesets.gpkg"),
+                                  append = FALSE, quiet = TRUE))
+  }
+
+} else {
+  # ---------- OVERLAY SAMPLING: sample IDs, then API details  ----------
+  cs_overlay  <- P("data","db_overlay","changesets_subset.csv")
+  if (!file.exists(cs_overlay)) {
+    warning("Overlay changesets_subset.csv not found; writing empty RAW and continuing.")
+    write_empty_changesets()
+  } else {
+    # Load overlay rows and normalise user column
+    cs_all <- readr::read_csv(cs_overlay, show_col_types = FALSE)
+    if (!"user" %in% names(cs_all) && "username" %in% names(cs_all)) {
+      cs_all <- dplyr::rename(cs_all, user = username)
+    }
+    cs_all <- cs_all |> dplyr::mutate(user = tolower(user))
+
+    # ---- per-user targets ----
+    per_user_n <- cs_all |> dplyr::count(user, name = "n_total")
+    alloc <- per_user_n
+
+    # --- NEW: Calculate target based on percentage (n_total * percentage) ---
+    alloc$n_target_raw <- ceiling(alloc$n_total * sample_perc_user)
+
+    if (sample_max_total > 0) {
+      # Use the proportionally calculated size as the effective 'per user cap'
+      user_cap <- alloc$n_target_raw
+
+      # Now, scale down the proportional targets if the total exceeds sample_max_total
+      w <- alloc$n_target_raw / sum(alloc$n_target_raw)
+      prop_n <- pmax(1L, floor(w * sample_max_total))
+
+      # The target is the proportional calculation, capped by the overall max_total constraint
+      alloc$n_target <- pmin(prop_n, user_cap)
+
+      overflow <- sum(alloc$n_target) - sample_max_total
+
+      # The complex overflow logic remains (simplified slightly here):
+      if (overflow > 0) {
+        ord <- order(alloc$n_target, decreasing = TRUE)
+        i <- 1L
+        while (overflow > 0 && i <= length(ord)) {
+          j <- ord[i]
+          can_reduce <- alloc$n_target[j] - 1L
+          if (can_reduce > 0L) {
+            take <- min(can_reduce, overflow)
+            alloc$n_target[j] <- alloc$n_target[j] - take
+            overflow <- overflow - take
+          }
+          i <- i + 1L
+        }
+      }
+    } else {
+      # No global cap: n_target is simply the proportional calculation
+      alloc$n_target <- alloc$n_target_raw
+    }
+
+    alloc <- alloc %>%
+      dplyr::mutate(n_target = as.integer(dplyr::coalesce(n_target, 0L)),
+                    n_target = pmax(0L, n_target)) %>%
+      dplyr::filter(n_target > 0L)
+
+    cat(sprintf("[sampling] users in overlay: %d | with target > 0: %d | total target: %d\n",
+                dplyr::n_distinct(cs_all$user), nrow(alloc), sum(alloc$n_target)))
+
+    # ---- sample overlay rows per user -> IDs only ----
+    set.seed(seed_val)
+    sampled <- cs_all %>%
+      dplyr::inner_join(alloc, by = "user") %>%
+      dplyr::group_by(user) %>%
+      dplyr::mutate(.rand = runif(dplyr::n())) %>%
+      dplyr::arrange(.rand, .by_group = TRUE) %>%
+      dplyr::mutate(.row = dplyr::row_number()) %>%
+      dplyr::filter(.row <= dplyr::first(n_target)) %>%
+      dplyr::ungroup() %>%
+      dplyr::select(-.rand, -.row)
+
+    # ---- fetch API details only for sampled IDs ----
+    sel_ids <- unique(na.omit(as.integer(sampled$id)))
+    if (!length(sel_ids)) {
+      write_empty_changesets()
+    } else {
+      id_batches <- split(sel_ids, ceiling(seq_along(sel_ids)/200))
+      changesets_details <- map_dfr(id_batches, ~ tryCatch(get_changesets_details(.x), error = function(e) NULL))
+
+      if (is.null(changesets_details) || !is.data.frame(changesets_details) || !nrow(changesets_details)) {
+        write_empty_changesets()
+      } else {
+        #derive tags BEFORE writing details
+
+        tags_df <- OSMdashboard::extract_and_combine_tags(changesets_details)
+
+        readr::write_csv(tags_df, P("data","raw","changesets_tags.csv"))
+
+        # Write details (strip list-cols)
+        details_clean <- changesets_details %>% dplyr::select(-dplyr::any_of(c("members","tags","tags_df")))
+        readr::write_csv(details_clean, P("data","raw","changesets_details.csv"))
+
+        # Build changesets.csv from API details + tags
+        det <- tibble::as_tibble(changesets_details)
+        n   <- nrow(det)
+        col_or_na <- function(df, nm, n) if (nm %in% names(df)) df[[nm]] else rep(NA, n)
+        first_of  <- function(df, n, ...) {
+          cands <- c(...)
+          hit <- cands[cands %in% names(df)]
+          if (length(hit)) df[[hit[1]]] else rep(NA, n)
+        }
+
+        id_vec      <- first_of(det, n, "changeset", "id")
+        user_vec    <- tolower(as.character(first_of(det, n, "user", "username")))
+        created_vec <- first_of(det, n, "created_at", "created", "timestamp")
+
+        core <- tibble::tibble(
+          id         = as.integer(id_vec),
+          user       = user_vec,
+          created_at = suppressWarnings(lubridate::ymd_hms(as.character(created_vec))),
+          min_lat    = suppressWarnings(as.numeric(col_or_na(det, "min_lat", n))),
+          min_lon    = suppressWarnings(as.numeric(col_or_na(det, "min_lon", n))),
+          max_lat    = suppressWarnings(as.numeric(col_or_na(det, "max_lat", n))),
+          max_lon    = suppressWarnings(as.numeric(col_or_na(det, "max_lon", n))),
+          created_by = as.character(col_or_na(det, "created_by", n)),
+          comment    = as.character(col_or_na(det, "comment", n))
+        ) %>% dplyr::distinct()
+
+        # Join locale/hashtags from tags
+        tags_wide <- if (nrow(tags_df)) {
+          tags_df %>%
+            dplyr::filter(key %in% c("locale","hashtags", "imagery")) %>%
+            dplyr::group_by(changeset, key) %>%
+            dplyr::summarise(value = dplyr::first(stats::na.omit(value)), .groups = "drop") %>%
+            tidyr::pivot_wider(names_from = key, values_from = value) %>%
+            dplyr::rename(id = changeset) %>%
+            # convert ID to an integer
+            dplyr::mutate(id = as.integer(id))
+        } else {
+          tibble::tibble(id = integer(), locale = character(), hashtags = character())
+        }
+
+        core <- core %>%
+          dplyr::left_join(tags_wide, by = "id") %>%
+          #Fill with NA if join fails
+          dplyr::mutate(
+            locale = if("locale" %in% names(.)) as.character(locale) else NA_character_,
+            hashtags = if("hashtags" %in% names(.)) as.character(hashtags) else NA_character_,
+            imagery = if("imagery" %in% names(.)) as.character(imagery) else NA_character_
+          )
+
+        # Fill bbox from overlay if API missed it
+        bbox_overlay <- sampled %>% dplyr::select(id, dplyr::any_of(c("min_lat","min_lon","max_lat","max_lon")))
+        if (nrow(bbox_overlay)) {
+          core <- core %>%
+            dplyr::left_join(bbox_overlay, by = "id", suffix = c("", "_ov")) %>%
+            dplyr::mutate(
+              min_lat = dplyr::coalesce(min_lat, .data$min_lat_ov),
+              min_lon = dplyr::coalesce(min_lon, .data$min_lon_ov),
+              max_lat = dplyr::coalesce(max_lat, .data$max_lat_ov),
+              max_lon = dplyr::coalesce(max_lon, .data$max_lon_ov)
+            ) %>%
+            dplyr::select(-dplyr::ends_with("_ov"))
+        }
+
+        readr::write_csv(core, P("data","raw","changesets.csv"))
+      }
+    }
+  }
+}
+
+# --------------------------------------------------
+# (D) RAW: Wiki
 # --------------------------------------------------
 wiki_contributions <- tryCatch(
   get_contributions_wiki(selected_users) %>%
@@ -157,39 +439,30 @@ wiki_contributions <- tryCatch(
     tibble::as_tibble(),
   error = function(e) tibble::tibble(user=character())
 )
-
 wiki_contributions_n <- wiki_contributions %>%
-  count(user) %>%
-  mutate(user = tolower(user)) %>%
-  rename(wiki_edits = n)
-
+  count(user) %>% mutate(user = tolower(user)) %>% rename(wiki_edits = n)
 write.csv(wiki_contributions, P("data","raw","wiki_contributions.csv"), row.names = FALSE)
 
 # --------------------------------------------------
-# Diaries
+# (E) RAW: Diaries
 # --------------------------------------------------
 users_diaries <- osm_user_details %>%
   mutate(user = tolower(user)) %>%
   filter(!is.na(diary), diary > 0) %>%
   pull(user) %>%
   unique()
-
-contributions_diaries <- tryCatch(
-  get_contributions_diaries(users_diaries),
-  error = function(e) tibble::tibble()
-)
-
+contributions_diaries <- tryCatch(get_contributions_diaries(users_diaries),
+                                  error = function(e) tibble::tibble())
 write.csv(contributions_diaries, P("data","raw","contributions_diaries.csv"), row.names = FALSE)
 
 # --------------------------------------------------
-# Contributions summary
+# (F) RAW: Contributions summary
 # --------------------------------------------------
 contributions_summary <- osm_user_details %>%
   mutate(
     user = tolower(user),
-    account_age    = as.integer(difftime(today(), date_creation,      units = "days")) / 365,
+    account_age      = as.integer(difftime(today(), date_creation,      units = "days")) / 365,
     map_activity_age = as.integer(difftime(date_last_map_edit, date_creation, units = "days")) / 365
   ) %>%
   left_join(wiki_contributions_n, by = "user")
-
 write.csv(contributions_summary, P("data","raw","contributions_summary.csv"), row.names = FALSE)

--- a/python/extract_group_users_from_definition.py
+++ b/python/extract_group_users_from_definition.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, os
+import pandas as pd
+import duckdb
+
+def _split_pipe(val):
+    if val is None or (isinstance(val, float) and pd.isna(val)): return []
+    s = str(val).strip()
+    if not s: return []
+    return [x.strip() for x in s.split("|") if x.strip()]
+
+def _parse_bbox(val):
+    if val is None or (isinstance(val, float) and pd.isna(val)): return None
+    parts = [p.strip() for p in str(val).split(",")]
+    if len(parts) != 4: return None
+    mnlat, mnlon, mxlat, mxlon = map(float, parts)
+    return (mnlat, mnlon, mxlat, mxlon)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True, help="Path to osm_changesets.duckdb")
+    ap.add_argument("--group-def", required=True, help="Path to data/metadata/group_definition.csv")
+    ap.add_argument("--out", default="data/metadata/group_users.csv", help="Output CSV (username only)")
+    args = ap.parse_args()
+
+    df = pd.read_csv(args.group_def)
+    if df.empty:
+        raise SystemExit("group_definition.csv is empty.")
+
+    # We assume a single active group (first row)
+    row = df.iloc[0]
+
+    tags_exact      = _split_pipe(row.get("Group_tags"))
+    tags_like       = _split_pipe(row.get("Group_liketags"))
+    comment_terms   = _split_pipe(row.get("Group_comment"))       # treated as substrings
+    comment_like    = _split_pipe(row.get("Group_likecomment"))   # treat as LIKE patterns
+    bbox            = _parse_bbox(row.get("Group_bbx"))
+    start_date      = str(row.get("Group_startdate")).strip() if pd.notna(row.get("Group_startdate")) else None
+    end_date        = str(row.get("Group_enddate")).strip() if pd.notna(row.get("Group_enddate")) else None
+
+    top_active = None
+    if "TopActive" in df.columns and pd.notna(row.get("TopActive")):
+        try:
+            ta = int(row["TopActive"])
+            if ta > 0:
+                top_active = ta
+        except Exception:
+            pass
+
+    #Build SQL (case-insensitive on hashtags/comments - only need usernames out)
+    base_where = ["WHERE 1=1 AND c.user IS NOT NULL"]
+    params = []
+
+    if start_date:
+        base_where.append("AND c.created >= ?")
+        params.append(pd.to_datetime(start_date))
+    if end_date:
+        base_where.append("AND c.created <= ?")
+        params.append(pd.to_datetime(end_date))
+    if bbox:
+        mnlat, mnlon, mxlat, mxlon = bbox
+        base_where.append("AND ((c.min_lat + c.max_lat)/2.0) BETWEEN ? AND ?")
+        base_where.append("AND ((c.min_lon + c.max_lon)/2.0) BETWEEN ? AND ?")
+        params.extend([mnlat, mxlat, mnlon, mxlon])
+
+    # Tag conditions (match against LOWER(h.hashtag)); we strip leading '#' and lowercase
+    tag_expr_parts, tag_params = [], []
+    t_exact = [t.lstrip("#").lower() for t in tags_exact]
+    if t_exact:
+        tag_expr_parts.append(f"LOWER(h.hashtag) IN ({','.join(['?']*len(t_exact))})")
+        tag_params.extend(t_exact)
+    for p in tags_like:
+        tag_expr_parts.append("LOWER(h.hashtag) LIKE ?")
+        tag_params.append(p.lower())
+
+    # Comment conditions (substring for Group_comment; raw LIKE for Group_likecomment)
+    cmt_expr_parts, cmt_params = [], []
+    for t in comment_terms:
+        cmt_expr_parts.append("LOWER(c.comment) LIKE ?")
+        cmt_params.append(f"%{t.lower()}%")
+    for p in comment_like:
+        cmt_expr_parts.append("LOWER(c.comment) LIKE ?")
+        cmt_params.append(p.lower())
+
+    if not tag_expr_parts and not cmt_expr_parts:
+        # Safety: require at least one of tags or comments to define the group
+        raise SystemExit("No tag/comment filters provided in group_definition.csv (nothing to select).")
+
+    #compose final predicate: EXISTS(tag match) OR (comment match)
+    tag_exists_sql = ""
+    if tag_expr_parts:
+        tag_exists_sql = "EXISTS (SELECT 1 FROM changeset_hashtags h WHERE h.changeset_id = c.changeset_id AND (" + " OR ".join(tag_expr_parts) + "))"
+    comment_sql = ""
+    if cmt_expr_parts:
+        comment_sql = "(" + " OR ".join(cmt_expr_parts) + ")"
+
+    any_match_sql = []
+    if tag_exists_sql: any_match_sql.append(tag_exists_sql)
+    if comment_sql:    any_match_sql.append(comment_sql)
+    any_match = " OR ".join(any_match_sql)
+
+    sql = f"""
+        SELECT LOWER(c.user) AS user, COUNT(*) AS n
+        FROM changesets c
+        {' '.join(base_where)}
+          AND ( {any_match} )
+        GROUP BY user
+        ORDER BY n DESC
+        {('LIMIT ' + str(top_active)) if top_active else ''}
+    """
+
+    all_params = params + tag_params + cmt_params
+
+    con = duckdb.connect(args.db, read_only=True)
+    try:
+        users = con.execute(sql, all_params).df()
+    finally:
+        con.close()
+
+    # Write only a single username column
+    out = (
+        users["user"]
+        .astype(str)
+        .str.strip()
+        .replace({"": None})
+        .dropna()
+        .drop_duplicates()
+        .sort_values()
+        .rename("username")
+        .to_frame()
+        .reset_index(drop=True)
+    )
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    out.to_csv(args.out, index=False)
+    print(f"Wrote {len(out)} usernames to {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/python/extract_group_users_from_definition.py
+++ b/python/extract_group_users_from_definition.py
@@ -1,56 +1,105 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, os
+import argparse, os, time, csv
+from typing import Optional, Tuple, List
 import pandas as pd
 import duckdb
 
-def _split_pipe(val):
+# --- helpers ---------------------------------------------------------
+
+def _split_pipe(val) -> List[str]:
     if val is None or (isinstance(val, float) and pd.isna(val)): return []
     s = str(val).strip()
     if not s: return []
     return [x.strip() for x in s.split("|") if x.strip()]
 
-def _parse_bbox(val):
+def _parse_bbox(val) -> Optional[Tuple[float,float,float,float]]:
     if val is None or (isinstance(val, float) and pd.isna(val)): return None
     parts = [p.strip() for p in str(val).split(",")]
     if len(parts) != 4: return None
     mnlat, mnlon, mxlat, mxlon = map(float, parts)
     return (mnlat, mnlon, mxlat, mxlon)
 
+# optional live validation (off by default)
+def _head_ok_cached(user: str, cache_file: str, sleep_min: float, sleep_max: float) -> bool:
+    try:
+        os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+        cache = {}
+        if os.path.exists(cache_file):
+            with open(cache_file, newline="", encoding="utf-8") as f:
+                for r in csv.DictReader(f):
+                    cache[r["username"]] = r["ok"] == "1"
+
+        if user in cache:
+            return cache[user]
+
+        import random, urllib.request
+        time.sleep(random.uniform(sleep_min, sleep_max))
+        req = urllib.request.Request(f"https://www.openstreetmap.org/user/{user}", method="HEAD")
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+                ok = (200 <= resp.status < 400)
+        except Exception:
+            ok = False  # be strict on errors
+
+        new = not os.path.exists(cache_file)
+        with open(cache_file, "a", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            if new:
+                w.writerow(["username","ok","ts"])
+            w.writerow([user, "1" if ok else "0", int(time.time())])
+
+        return ok
+    except Exception:
+        return True  #don't block on cache errors
+
+# --- main -------------------------------------------------------------
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--db", required=True, help="Path to osm_changesets.duckdb")
     ap.add_argument("--group-def", required=True, help="Path to data/metadata/group_definition.csv")
     ap.add_argument("--out", default="data/metadata/group_users.csv", help="Output CSV (username only)")
+    ap.add_argument("--max-users", type=int, default=None, help="Cap number of users (top N by activity)")
+    ap.add_argument("--validate-live", action="store_true", help="Drop usernames that 404 on OSM website (polite, cached)")
+    ap.add_argument("--sleep-min", type=float, default=0.6)
+    ap.add_argument("--sleep-max", type=float, default=1.4)
+    ap.add_argument("--valid-cache", default="data/processed/.user_valid_cache.csv")
     args = ap.parse_args()
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+
+    def write_empty_and_exit(msg: str):
+        # Always write a CSV with just the header so R never fails on "no columns"
+        pd.DataFrame(columns=["username"]).to_csv(args.out, index=False)
+        print(msg)
+        raise SystemExit(0)
 
     df = pd.read_csv(args.group_def)
     if df.empty:
-        raise SystemExit("group_definition.csv is empty.")
+        write_empty_and_exit("group_definition.csv is empty — wrote an empty group_users.csv")
 
-    # We assume a single active group (first row)
     row = df.iloc[0]
-
-    tags_exact      = _split_pipe(row.get("Group_tags"))
-    tags_like       = _split_pipe(row.get("Group_liketags"))
-    comment_terms   = _split_pipe(row.get("Group_comment"))       # treated as substrings
-    comment_like    = _split_pipe(row.get("Group_likecomment"))   # treat as LIKE patterns
-    bbox            = _parse_bbox(row.get("Group_bbx"))
-    start_date      = str(row.get("Group_startdate")).strip() if pd.notna(row.get("Group_startdate")) else None
-    end_date        = str(row.get("Group_enddate")).strip() if pd.notna(row.get("Group_enddate")) else None
+    tags_exact    = _split_pipe(row.get("Group_tags"))
+    tags_like     = _split_pipe(row.get("Group_liketags"))
+    comment_terms = _split_pipe(row.get("Group_comment"))
+    comment_like  = _split_pipe(row.get("Group_likecomment"))
+    bbox          = _parse_bbox(row.get("Group_bbx"))
+    start_date    = str(row.get("Group_startdate")).strip() if pd.notna(row.get("Group_startdate")) else None
+    end_date      = str(row.get("Group_enddate")).strip() if pd.notna(row.get("Group_enddate")) else None
 
     top_active = None
     if "TopActive" in df.columns and pd.notna(row.get("TopActive")):
         try:
-            ta = int(row["TopActive"])
-            if ta > 0:
-                top_active = ta
+            t = int(row["TopActive"])
+            if t > 0:
+                top_active = t
         except Exception:
             pass
 
-    #Build SQL (case-insensitive on hashtags/comments - only need usernames out)
-    base_where = ["WHERE 1=1 AND c.user IS NOT NULL"]
-    params = []
+    # Build shared WHERE for date/bbox on changesets
+    base_where = ["WHERE 1=1 AND c.uid IS NOT NULL"]
+    params: List = []
 
     if start_date:
         base_where.append("AND c.created >= ?")
@@ -64,74 +113,112 @@ def main():
         base_where.append("AND ((c.min_lon + c.max_lon)/2.0) BETWEEN ? AND ?")
         params.extend([mnlat, mxlat, mnlon, mxlon])
 
-    # Tag conditions (match against LOWER(h.hashtag)); we strip leading '#' and lowercase
-    tag_expr_parts, tag_params = [], []
+    # Tag/Comment predicates
+    tag_parts, tag_params = [], []
     t_exact = [t.lstrip("#").lower() for t in tags_exact]
     if t_exact:
-        tag_expr_parts.append(f"LOWER(h.hashtag) IN ({','.join(['?']*len(t_exact))})")
+        tag_parts.append(f"LOWER(h.hashtag) IN ({','.join(['?']*len(t_exact))})")
         tag_params.extend(t_exact)
     for p in tags_like:
-        tag_expr_parts.append("LOWER(h.hashtag) LIKE ?")
+        tag_parts.append("LOWER(h.hashtag) LIKE ?")
         tag_params.append(p.lower())
 
-    # Comment conditions (substring for Group_comment; raw LIKE for Group_likecomment)
-    cmt_expr_parts, cmt_params = [], []
+    c_parts, c_params = [], []
     for t in comment_terms:
-        cmt_expr_parts.append("LOWER(c.comment) LIKE ?")
-        cmt_params.append(f"%{t.lower()}%")
+        c_parts.append("LOWER(c.comment) LIKE ?")
+        c_params.append(f"%{t.lower()}%")
     for p in comment_like:
-        cmt_expr_parts.append("LOWER(c.comment) LIKE ?")
-        cmt_params.append(p.lower())
-
-    if not tag_expr_parts and not cmt_expr_parts:
-        # Safety: require at least one of tags or comments to define the group
-        raise SystemExit("No tag/comment filters provided in group_definition.csv (nothing to select).")
-
-    #compose final predicate: EXISTS(tag match) OR (comment match)
-    tag_exists_sql = ""
-    if tag_expr_parts:
-        tag_exists_sql = "EXISTS (SELECT 1 FROM changeset_hashtags h WHERE h.changeset_id = c.changeset_id AND (" + " OR ".join(tag_expr_parts) + "))"
-    comment_sql = ""
-    if cmt_expr_parts:
-        comment_sql = "(" + " OR ".join(cmt_expr_parts) + ")"
-
-    any_match_sql = []
-    if tag_exists_sql: any_match_sql.append(tag_exists_sql)
-    if comment_sql:    any_match_sql.append(comment_sql)
-    any_match = " OR ".join(any_match_sql)
-
-    sql = f"""
-        SELECT LOWER(c.user) AS user, COUNT(*) AS n
-        FROM changesets c
-        {' '.join(base_where)}
-          AND ( {any_match} )
-        GROUP BY user
-        ORDER BY n DESC
-        {('LIMIT ' + str(top_active)) if top_active else ''}
-    """
-
-    all_params = params + tag_params + cmt_params
+        c_parts.append("LOWER(c.comment) LIKE ?")
+        c_params.append(p.lower())
 
     con = duckdb.connect(args.db, read_only=True)
+
     try:
-        users = con.execute(sql, all_params).df()
+        # CASE A: no tag/comment filters → if TopActive provided, take global top users (respect date/bbox)
+        if not tag_parts and not c_parts:
+            if top_active is None and args.max_users is None:
+                write_empty_and_exit("No tag/comment filters and no TopActive — wrote empty group_users.csv")
+
+            sql = f"""
+            WITH users_latest AS (
+              SELECT uid, arg_max(user, created) AS latest_username
+              FROM changesets
+              WHERE uid IS NOT NULL AND user IS NOT NULL
+              GROUP BY uid
+            ),
+            base AS (
+              SELECT c.uid, COUNT(*) AS n
+              FROM changesets c
+              {' '.join(base_where)}
+              GROUP BY c.uid
+            )
+            SELECT LOWER(u.latest_username) AS username, b.n
+            FROM base b
+            JOIN users_latest u USING (uid)
+            WHERE u.latest_username IS NOT NULL
+            ORDER BY b.n DESC
+            {('LIMIT ' + str(int(args.max_users))) if args.max_users
+              else (('LIMIT ' + str(int(top_active))) if top_active else '')}
+            """
+            users = con.execute(sql, params).df()
+
+        # CASE B: tag/comment filters present
+        else:
+            tag_exists = ""
+            if tag_parts:
+                tag_exists = ("EXISTS (SELECT 1 FROM changeset_hashtags h "
+                              "WHERE h.changeset_id = c.changeset_id AND (" + " OR ".join(tag_parts) + "))")
+            comment_pred = "(" + " OR ".join(c_parts) + ")" if c_parts else ""
+            any_match = " OR ".join([p for p in [tag_exists, comment_pred] if p])
+
+            sql = f"""
+            WITH users_latest AS (
+              SELECT
+                uid,
+                arg_max(user, created) AS latest_username
+              FROM changesets
+              WHERE uid IS NOT NULL AND user IS NOT NULL
+              GROUP BY uid
+            ),
+            base AS (
+              SELECT c.uid, COUNT(*) AS n
+              FROM changesets c
+              {' '.join(base_where)}
+                AND ( {any_match} )
+              GROUP BY c.uid
+            )
+            SELECT LOWER(u.latest_username) AS username, b.n
+            FROM base b
+            JOIN users_latest u USING (uid)
+            WHERE u.latest_username IS NOT NULL
+            ORDER BY b.n DESC
+            {('LIMIT ' + str(int(args.max_users))) if args.max_users
+              else (('LIMIT ' + str(int(top_active))) if top_active else '')}
+            """
+            users = con.execute(sql, params + tag_params + c_params).df()
+
     finally:
         con.close()
 
-    # Write only a single username column
-    out = (
-        users["user"]
-        .astype(str)
-        .str.strip()
-        .replace({"": None})
-        .dropna()
-        .drop_duplicates()
-        .sort_values()
-        .rename("username")
-        .to_frame()
-        .reset_index(drop=True)
-    )
-    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    #Write just the username column -if empty, still write header
+    out = (users["username"]
+           .astype(str).str.strip()
+           .replace({"": None}).dropna()
+           .drop_duplicates().sort_values().to_frame())
+
+    if out.empty:
+        pd.DataFrame(columns=["username"]).to_csv(args.out, index=False)
+        print("No users matched this group definition — wrote an empty group_users.csv")
+        raise SystemExit(0)
+
+    #optional live validation
+    if args.validate_live:
+        keep = []
+        for u in out["username"]:
+            if _head_ok_cached(u, args.valid_cache, args.sleep_min, args.sleep_max):
+                keep.append(u)
+        out = pd.DataFrame({"username": keep})
+
     out.to_csv(args.out, index=False)
     print(f"Wrote {len(out)} usernames to {args.out}")
 

--- a/python/overlay.py
+++ b/python/overlay.py
@@ -100,15 +100,15 @@ def build_overlay(
         .tolist()
     )
 
-    # extra usernames param
+    #extra usernames param
     param_usernames = [u.strip().lower() for u in _ensure_list(usernames) if u.strip()] if usernames else []
 
-    # decide target users
+    #decide target users
     target_users = sorted(set(csv_usernames)) if strict_group_only else sorted(set(csv_usernames) | set(param_usernames))
     if not target_users:
         raise RuntimeError("No usernames found (after normalization).")
 
-    # optionally pull start/end from group_info.csv
+    #optionally pull start/end from group_info.csv
     if use_group_info_dates and os.path.exists(group_info_csv):
         try:
             gdf = pd.read_csv(group_info_csv)
@@ -185,7 +185,7 @@ def build_overlay(
           c.created_by,
           c.imagery_used,
           c.source,
-          c.min_lat, c.min_lon, c.max_lat, c.max_lon
+          c.min_lat, c.min_lon, c.max_lat, c.max_lon, c.locale
         FROM changesets c
         {join_hashtags}
         {' '.join(where)}

--- a/python/overlay.py
+++ b/python/overlay.py
@@ -55,6 +55,7 @@ def build_overlay(
     out_dir: str = "data/db_overlay",
     usernames: Optional[Iterable[str]] = None,      # optional extras
     hashtags: Optional[Iterable[str]] = None,       # optional filter
+    like_hashtags: Optional[Iterable[str]] = None,  # optional filter
     start: Optional[str] = None,                    # optional filter
     end: Optional[str] = None,                      # optional filter
     bbox: Optional[Tuple[float, float, float, float]] = None,  # (min_lat,min_lon,max_lat,max_lon)
@@ -151,13 +152,27 @@ def build_overlay(
 
         # optional hashtag filter
         join_hashtags = ""
+        has_where_clauses = []
         if hashtags:
             tags = [h.strip() for h in _ensure_list(hashtags) if h.strip()]
             if tags:
                 join_hashtags = "JOIN changeset_hashtags h ON h.changeset_id = c.changeset_id"
                 placeholders_tags = ",".join(["?"] * len(tags))
-                where.append(f"AND h.hashtag IN ({placeholders_tags})")
+                has_where_clauses.append(f"h.hashtag IN ({placeholders_tags})")
                 params.extend(tags)
+        
+        if like_hashtags:
+            likes = [h.strip().lower() for h in _ensure_list(like_hashtags) if h.strip()]
+            if likes:
+                if not join_hashtags:
+                    join_hashtags = "JOIN changeset_hashtags h ON h.changeset_id = c.changeset_id"
+                # build OR (h.hashtag ILIKE ? OR ...)
+                like_sql = " OR ".join(["lower(h.hashtag) LIKE ?"] * len(likes))
+                has_where_clauses.append(f"({like_sql})")
+                params.extend([f"%{s}%" for s in likes])
+        
+        if has_where_clauses:
+            where.append("AND (" + " OR ".join(has_where_clauses) + ")")
 
         # fetch changesets for the group users
         sql = f"""

--- a/python/queries.py
+++ b/python/queries.py
@@ -165,7 +165,7 @@ def get_changesets_for_hashtags(
           SELECT DISTINCT
             c.changeset_id, c.user, c.uid, c.created, c.comment,
             c.created_by, c.imagery_used, c.source,
-            c.min_lat, c.min_lon, c.max_lat, c.max_lon
+            c.min_lat, c.min_lon, c.max_lat, c.max_lon, c.locale
           FROM changesets c
           JOIN wanted w USING (changeset_id)
           WHERE 1=1

--- a/python/queries.py
+++ b/python/queries.py
@@ -48,9 +48,9 @@ import pandas as pd
 from typing import Iterable, Optional, Tuple, Union
 import os
 from datetime import datetime
-# os.makedirs("QueryResults", exist_ok=True)
+os.makedirs("QueryResults", exist_ok=True)
 
-# #If you have a different name for your database, plesae change it here
+#If you have a different name for your database, plesae change it here
 DB_PATH_DEFAULT = "osm_changesets.duckdb"
 
 # Helper functions to insure inputs are in list formats
@@ -104,30 +104,137 @@ def connect(db_path: str = DB_PATH_DEFAULT):
     """Return a DuckDB connection (caller can reuse it and close when done)."""
     return duckdb.connect(db_path, read_only=True)
 
-
-#These are the queries. Additional filters (above) are added to these queries depending on the arguments given
-
-def get_users_for_hashtag(
-    hashtag: Union[str, Iterable[str]],
+def get_changesets_for_hashtags(
     *,
+    hashtag: Optional[Union[str, Iterable[str]]] = None,
+    like: Optional[Union[str, Iterable[str]]] = None,
     start_date: Optional[Union[str, pd.Timestamp]] = None,
     end_date: Optional[Union[str, pd.Timestamp]] = None,
-    bbox: Optional[Tuple[float,float,float,float]] = None,  # (min_lat, min_lon, max_lat, max_lon)
+    bbox: Optional[Tuple[float,float,float,float]] = None,
+    order_by: Optional[str] = "created_at DESC",
+    limit: Optional[int] = None,
+    db_path: str = DB_PATH_DEFAULT,
+    to_csv: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    DISTINCT changesets whose hashtags match given tokens and/or LIKE patterns.
+    Returns one row per changeset with aggregated ';'-joined hashtags.
+    """
+    exact = _ensure_list(hashtag) or []
+    like_patterns = [str(s) for s in (_ensure_list(like) or []) if str(s).strip()]
+
+    con = connect(db_path)
+    try:
+        where_tags = ["WHERE 1=1"]
+        params: list = []
+
+        # Build tag conditions for the changeset_hashtags table
+        tag_conds = []
+        if exact:
+            exact = [str(s) for s in exact]
+            with_hash    = [s for s in exact if s.startswith("#")]
+            without_hash = [s for s in exact if not s.startswith("#")]
+
+            sub = []
+            if without_hash:
+                ph = ",".join(["?"] * len(without_hash))
+                sub.append(f"hashtag IN ({ph})")
+                params.extend(without_hash)
+            if with_hash:
+                ph = ",".join(["?"] * len(with_hash))
+                sub.append(f"hashtag_raw IN ({ph})")
+                params.extend(with_hash)
+            if sub:
+                tag_conds.append("(" + " OR ".join(sub) + ")")
+
+        for p in like_patterns:
+            tag_conds.append("(hashtag LIKE ? OR hashtag_raw LIKE ?)")
+            params.extend([p, p])
+
+        if tag_conds:
+            where_tags.append("AND (" + " OR ".join(tag_conds) + ")")
+
+        # Collect candidate changeset_ids by tag filter, then fetch base rows
+        sql = f"""
+        WITH wanted AS (
+          SELECT DISTINCT changeset_id
+          FROM changeset_hashtags
+          {' '.join(where_tags)}
+        ),
+        base AS (
+          SELECT DISTINCT
+            c.changeset_id, c.user, c.uid, c.created, c.comment,
+            c.created_by, c.imagery_used, c.source,
+            c.min_lat, c.min_lon, c.max_lat, c.max_lon
+          FROM changesets c
+          JOIN wanted w USING (changeset_id)
+          WHERE 1=1
+        """
+        # dates & bbox apply to the changeset itself
+        if start_date is not None:
+            sql += " AND c.created >= ?"
+            params.append(pd.to_datetime(start_date))
+        if end_date is not None:
+            sql += " AND c.created <= ?"
+            params.append(pd.to_datetime(end_date))
+        if bbox:
+            min_lat, min_lon, max_lat, max_lon = bbox
+            sql += " AND ((c.min_lat + c.max_lat)/2.0) BETWEEN ? AND ?"
+            sql += " AND ((c.min_lon + c.max_lon)/2.0) BETWEEN ? AND ?"
+            params.extend([min_lat, max_lat, min_lon, max_lon])
+        sql += """
+        ),
+        tags AS (
+          SELECT t.changeset_id, string_agg(t.hashtag, ';') AS hashtags
+          FROM (
+            SELECT DISTINCT changeset_id, hashtag
+            FROM changeset_hashtags
+            WHERE changeset_id IN (SELECT changeset_id FROM base)
+          ) t
+          GROUP BY t.changeset_id
+        )
+        SELECT
+          b.changeset_id AS id, b.user, b.uid, b.created AS created_at,
+          b.comment, b.created_by, b.imagery_used, b.source,
+          b.min_lat, b.min_lon, b.max_lat, b.max_lon,
+          COALESCE(tags.hashtags, '') AS hashtags
+        FROM base b
+        LEFT JOIN tags USING (changeset_id)
+        """
+        sql += _order_and_limit(order_by, limit)
+
+        df = con.execute(sql, params).df()
+        if to_csv:
+            df.to_csv(to_csv, index=False)
+        return df
+    finally:
+        con.close()
+
+def get_users_for_hashtag(
+    hashtag: Union[str, Iterable[str]] = None,
+    *,
+    like: Optional[Union[str, Iterable[str]]] = None,
+    start_date: Optional[Union[str, pd.Timestamp]] = None,
+    end_date: Optional[Union[str, pd.Timestamp]] = None,
+    bbox: Optional[Tuple[float,float,float,float]] = None,
     order_by: Optional[str] = "n DESC",
     limit: Optional[int] = None,
     db_path: str = DB_PATH_DEFAULT,
     to_csv: Optional[str] = None,
 ) -> pd.DataFrame:
-    
-    #This returns users who used a given hashtag(s), optionally filtered by a date range and bounding box.
-    #Counts per user are aggregated.
-    hashtags = _ensure_list(hashtag)
+    """
+    Users who used given hashtags and/or LIKE patterns.
+    - hashtag: exact tokens (as given; case and leading '#' are respected)
+    - like: SQL LIKE patterns (applied to BOTH hashtag and hashtag_raw)
+    """
+    exact = _ensure_list(hashtag) or []
+    like_patterns = [str(s) for s in (_ensure_list(like) or []) if str(s).strip()]
+
     con = connect(db_path)
     try:
         where = ["WHERE 1=1"]
-        params = []
+        params: list = []
 
-        # join to changesets for bbox + created
         sql = """
         SELECT
           h.uid,
@@ -139,9 +246,36 @@ def get_users_for_hashtag(
         JOIN changesets c USING (changeset_id)
         """
 
-        _add_in_clause(where, params, "h.hashtag", hashtags, cast=None)
+        # Build tag conditions (exact + like) without normalization
+        tag_conds = []
+        if exact:
+            exact = [str(s) for s in exact]
+            with_hash    = [s for s in exact if s.startswith("#")]
+            without_hash = [s for s in exact if not s.startswith("#")]
+
+            sub = []
+            if without_hash:
+                ph = ",".join(["?"] * len(without_hash))
+                sub.append(f"h.hashtag IN ({ph})")          # matches normalized tokens
+                params.extend(without_hash)
+            if with_hash:
+                ph = ",".join(["?"] * len(with_hash))
+                sub.append(f"h.hashtag_raw IN ({ph})")      # matches original text with '#'
+                params.extend(with_hash)
+            if sub:
+                tag_conds.append("(" + " OR ".join(sub) + ")")
+
+        for p in like_patterns:
+            tag_conds.append("(h.hashtag LIKE ? OR h.hashtag_raw LIKE ?)")
+            params.extend([p, p])
+
+        if tag_conds:
+            where.append("AND (" + " OR ".join(tag_conds) + ")")
+
         _add_date_range(where, params, "h.created", start_date, end_date)
-        _add_bbox(where, params, "(c.min_lat + c.max_lat)/2.0", "(c.min_lon + c.max_lon)/2.0", bbox)
+        _add_bbox(where, params,
+                  "(c.min_lat + c.max_lat)/2.0", "(c.min_lon + c.max_lon)/2.0",
+                  bbox)
 
         sql += " " + " ".join(where) + " GROUP BY h.uid, h.user "
         sql += _order_and_limit(order_by, limit)
@@ -153,6 +287,74 @@ def get_users_for_hashtag(
     finally:
         con.close()
 
+def get_changesets_for_comment(
+    *,
+    contains: Optional[Union[str, Iterable[str]]] = None,   # tokens -> ILIKE '%token%'
+    like: Optional[Union[str, Iterable[str]]] = None,       #raw LIKE patterns
+    start_date: Optional[Union[str, pd.Timestamp]] = None,
+    end_date: Optional[Union[str, pd.Timestamp]] = None,
+    bbox: Optional[Tuple[float,float,float,float]] = None,
+    order_by: Optional[str] = "created_at DESC",
+    limit: Optional[int] = None,
+    db_path: str = DB_PATH_DEFAULT,
+    to_csv: Optional[str] = None,
+) -> pd.DataFrame:
+    con = connect(db_path)
+    try:
+        where = ["WHERE 1=1"]
+        params: list = []
+
+        #comment token contains (case-insensitive)
+        tokens = _ensure_list(contains) or []
+        for t in tokens:
+            where.append("AND c.comment ILIKE ?")
+            params.append(f"%{str(t)}%")
+
+        #raw LIKE patterns for comment (if you plain words passed, they will still be treated as %word%)
+        pats = _ensure_list(like) or []
+        for p in pats:
+            p = str(p)
+            if "%" not in p:
+                p = f"%{p}%"
+            where.append("AND c.comment LIKE ?")
+            params.append(p)
+
+        _add_date_range(where, params, "c.created", start_date, end_date)
+        _add_bbox(where, params, "((c.min_lat + c.max_lat)/2.0)", "((c.min_lon + c.max_lon)/2.0)", bbox)
+
+        sql = """
+        WITH base AS (
+          SELECT DISTINCT
+            c.changeset_id, c.user, c.uid, c.created, c.comment,
+            c.created_by, c.imagery_used, c.source,
+            c.min_lat, c.min_lon, c.max_lat, c.max_lon
+          FROM changesets c
+          """ + " ".join(where) + """
+        ),
+        tags AS (
+          SELECT t.changeset_id, string_agg(t.hashtag, ';') AS hashtags
+          FROM (
+            SELECT DISTINCT changeset_id, hashtag
+            FROM changeset_hashtags
+            WHERE changeset_id IN (SELECT changeset_id FROM base)
+          ) t
+          GROUP BY t.changeset_id
+        )
+        SELECT
+          b.changeset_id AS id, b.user, b.uid, b.created AS created_at,
+          b.comment, b.created_by, b.imagery_used, b.source,
+          b.min_lat, b.min_lon, b.max_lat, b.max_lon,
+          COALESCE(tags.hashtags, '') AS hashtags
+        FROM base b
+        LEFT JOIN tags USING (changeset_id)
+        """ + _order_and_limit(order_by, limit)
+
+        df = con.execute(sql, params).df()
+        if to_csv:
+            df.to_csv(to_csv, index=False)
+        return df
+    finally:
+        con.close()
 
 def get_hashtags_for_users(
     *,
@@ -505,6 +707,96 @@ def count_hashtag(
     finally:
         con.close()
 
+def get_distinct_changesets_for_users(
+    usernames: Union[str, Iterable[str]],
+    *,
+    start_date: Optional[Union[str, pd.Timestamp]] = None,
+    end_date: Optional[Union[str, pd.Timestamp]] = None,
+    bbox: Optional[Tuple[float,float,float,float]] = None,  # (min_lat, min_lon, max_lat, max_lon) on centroid
+    limit: Optional[int] = None,
+    db_path: str = DB_PATH_DEFAULT,
+    to_csv: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    Return DISTINCT changesets for the given usernames (case-insensitive),
+    with hashtags aggregated into a single ';' separated string per changeset.
+    Optional date and bbox filters apply to the changeset's created timestamp and centroid.
+
+    Columns returned:
+      id, user, uid, created_at, comment, created_by, imagery_used, source,
+      min_lat, min_lon, max_lat, max_lon, hashtags
+    """
+    names = _ensure_list(usernames)
+    if not names:
+        return pd.DataFrame(columns=[
+            "id","user","uid","created_at","comment","created_by","imagery_used",
+            "source","min_lat","min_lon","max_lat","max_lon","hashtags"
+        ])
+
+    con = connect(db_path)
+    try:
+        where = ["WHERE 1=1"]
+        params: list = []
+
+        # filter by usernames (case-insensitive)
+        _add_in_clause(where, params, "lower(c.user)", [n.lower() for n in names], cast=None)
+
+        # optional filters
+        _add_date_range(where, params, "c.created", start_date, end_date)
+        _add_bbox(where, params,
+                  "((c.min_lat + c.max_lat)/2.0)", "((c.min_lon + c.max_lon)/2.0)",
+                  bbox)
+
+        #DISTINCT base set of changesets for those users
+        #then LEFT JOIN aggregated hashtags (distinct) to avoid row multiplication
+        sql = f"""
+        WITH base AS (
+            SELECT DISTINCT
+                c.changeset_id,
+                c.user,
+                c.uid,
+                c.created,
+                c.comment,
+                c.created_by,
+                c.imagery_used,
+                c.source,
+                c.min_lat, c.min_lon, c.max_lat, c.max_lon
+            FROM changesets c
+            {' '.join(where)}
+        ),
+        tags AS (
+            SELECT t.changeset_id,
+                   string_agg(t.hashtag, ';') AS hashtags
+            FROM (
+                SELECT DISTINCT changeset_id, hashtag
+                FROM changeset_hashtags
+                WHERE changeset_id IN (SELECT changeset_id FROM base)
+            ) AS t
+            GROUP BY t.changeset_id
+        )
+        SELECT
+            b.changeset_id AS id,
+            b.user,
+            b.uid,
+            b.created      AS created_at,
+            b.comment,
+            b.created_by,
+            b.imagery_used,
+            b.source,
+            b.min_lat, b.min_lon, b.max_lat, b.max_lon,
+            COALESCE(tags.hashtags, '') AS hashtags
+        FROM base b
+        LEFT JOIN tags USING (changeset_id)
+        ORDER BY created_at DESC
+        {('LIMIT ' + str(int(limit))) if limit is not None else ''}
+        """
+
+        df = con.execute(sql, params).df()
+        if to_csv:
+            df.to_csv(to_csv, index=False)
+        return df
+    finally:
+        con.close()
 
 def count_user_changes(
     *,
@@ -531,6 +823,18 @@ def count_user_changes(
         return con.execute(sql, params).df()
     finally:
         con.close()
+
+if __name__ == "__main__":
+
+    # #Choose the function that you want to use to access information from the database
+    # result_dataframe = get_hashtags_between_dates(start_date = "2025-01-01", end_date = "2025-08-10")
+
+    # #Enter your filepath here to save to a .csv file
+    # result_dataframe.to_csv('all_hashtags_between_01012025_and_10082025.csv', index=False) 
+
+    result_dataframe = get_all_users()
+
+    result_dataframe.to_csv('all_users.csv', index = False)
 
 def make_filename(prefix, start_date=None, end_date=None, bbox=None):
     """

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,7 @@
+duckdb
+numpy
+pandas
+pyarrow
+requests
+
+tzdata ; platform_system == "Windows"


### PR DESCRIPTION
In this sub-branch of integrate_database, we design the dashboard to pull users and information directly from a group definition written in a .csv group_definition rather than from group_users. This allows groups to be defined directly within the dashboard files, and users loaded from the database automatically, instead of being sourced elsewhere. 

The group can be defined by any combination of hashtags, comments, bounding box, start and end date, and a top filter. The top filter pertains only to users. For example, the top 10 most active users could be returned. When data_retrieval.R is run, the group_description populates a group_users.csv file, with all the users matching the description within the group. The rest of the data retrieval and dashboard rendering proceeds as normal within the integrate_database branch. This allows groups to be defined directly within the dashboard files, and users loaded from the database automatically, instead of being sourced elsewhere. 